### PR TITLE
feat(design-system): canonical icon re-exports + MenuList primitive [Slice J]

### DIFF
--- a/components/ui/menu-list.tsx
+++ b/components/ui/menu-list.tsx
@@ -1,0 +1,54 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Menu list primitive — the canonical chrome for dropdown menus across the app.
+ *
+ * Implements the legacy @mixin menu-modal() recipe from
+ * frontend/src/assets/styles/setup/_mixins.scss:107-132.
+ *
+ * Usage:
+ *   <MenuList>
+ *     <MenuListItem onClick={...}>Rename</MenuListItem>
+ *     <MenuListItem onClick={...}>Delete</MenuListItem>
+ *   </MenuList>
+ *
+ * Wrap in a <Popover> or <Dialog> for positioning.
+ */
+export function MenuList({ className, children, ...props }: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-0 rounded-md border bg-surface p-2 text-sm text-fg shadow-[var(--shadow-modal)]",
+        "border-[color:var(--color-border-strong)]",
+        "z-[var(--z-popover)]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function MenuListItem({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"button">) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-1 text-left",
+        "hover:bg-surface-hover",
+        "focus-visible:bg-surface-hover focus-visible:outline-none",
+        "disabled:opacity-50 disabled:cursor-not-allowed",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/lib/icons.ts
+++ b/lib/icons.ts
@@ -1,0 +1,40 @@
+/**
+ * Canonical icon module.
+ *
+ * The ONLY file allowed to import from `lucide-react`. All other code imports
+ * from `@/lib/icons`. Mapping back to legacy react-icons is documented in
+ * `docs/conversion-plan/design-system.md` §9.2.
+ */
+export {
+  // View kinds
+  BarChart3 as IconViewDashboard,
+  Bold as IconBold,
+  // Status / interaction
+  Check as IconCheck,
+  Circle as IconCircle,
+  CircleArrowDown as IconArrowDown,
+  CircleArrowRight as IconArrowRight,
+  CirclePlus as IconCirclePlus,
+  Columns3 as IconViewKanban,
+  FilePlus as IconFileAdd,
+  Home as IconHome,
+  LogIn as IconLogIn,
+  Maximize2 as IconExpand,
+  Menu as IconMenu,
+  MessageCircle as IconComment,
+  MessageSquarePlus as IconCommentAdd,
+  // Menus / overflow
+  MoreHorizontal as IconMore,
+  Pin as IconPin,
+  // Common actions
+  Plus as IconPlus,
+  Search as IconSearch,
+  Square as IconSquare,
+  Star as IconStar,
+  Trash2 as IconDelete,
+  User as IconViewPerson,
+  X as IconClose,
+  XCircle as IconCloseCircle,
+  // Workspace / brand
+  Zap as IconLightning,
+} from "lucide-react";


### PR DESCRIPTION
## Summary

- **`lib/icons.ts`** — single canonical re-export module for `lucide-react`. Maps legacy `react-icons` names (Bs/Ai/Bi/Hi/Tb sets) to Lucide equivalents per `design-system.md §9.2`. All other code must import from `@/lib/icons`, never from `lucide-react` directly.
- **`components/ui/menu-list.tsx`** — `MenuList` / `MenuListItem` primitive implementing the `@mixin menu-modal()` recipe from `_mixins.scss:107-132` per `component-system.md §3.2`. Tokens reference the canonical palette (`bg-surface`, `bg-surface-hover`, `--color-border-strong`, `--shadow-modal`, `--z-popover`).

## Branch naming deviation

The spec called for a nested branch `epic/01-followup-design-system/slice-j`, but git's ref namespace rule prevents a file and a directory sharing the same path — `epic/01-followup-design-system` already exists as a leaf branch on origin. This PR uses the flat naming `slice-j/01-followup-design-system`, consistent with Slice I (PR #37).

## Spec reference

`docs/conversion-plan/_dispatch/epic-01-followup-2.md`

## Verification

- `pnpm typecheck` — pass (0 errors)
- `pnpm lint` — pass (0 errors)
- `pnpm build` — pass
- No `lucide-react` imports outside `lib/icons.ts` (pre-existing `components/ui/sonner.tsx` exempted per spec note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)