### PR TITLE
Epic 01 followup 2: design-system retrofit (Monday-derived tokens + Figtree/Poppins + icon module + MenuList)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,26 +4,130 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* THEME_TOKENS — owned by Slice B */
+/* THEME_TOKENS — canonical Monday-derived palette (epic-01-followup-2 Slice I) */
 
 @theme {
-  --color-bg: oklch(99% 0 0);
-  --color-bg-subtle: oklch(97% 0 0);
-  --color-fg: oklch(20% 0 0);
-  --color-fg-muted: oklch(45% 0 0);
-  --color-border: oklch(92% 0 0);
-  --color-primary: oklch(58% 0.2 260);
-  --color-primary-fg: oklch(99% 0 0);
-  --color-danger: oklch(60% 0.22 25);
-  --color-success: oklch(62% 0.18 145);
-  --color-warning: oklch(75% 0.16 75);
+  /* App surface */
+  --color-surface: #ffffff;
+  --color-surface-auth: #f7f7f7;
+  --color-surface-rail: #f6f7fb;
+  --color-surface-nav: #292f4c;
+  --color-surface-info: #f5f6f8;
+  --color-surface-row-hover: #f4f5f8;
+  --color-surface-hover: #dcdfec;
+  --color-surface-active: #cce5ff;
+  --color-primary-selected: #cce5ff;
+  --color-primary-selected-hover: #aed4fc;
+  --color-card-selected: #d9f0ff;
+  --color-chip-member: #e5f4ff;
 
-  --radius-sm: 0.25rem;
-  --radius-md: 0.5rem;
-  --radius-lg: 0.75rem;
+  /* Primary (Monday blue) */
+  --color-primary: #0073ea;
+  --color-primary-hover: #0060b9;
+  --color-primary-foreground: #ffffff;
+  --color-link: #1f76c2;
+  --color-nav-icon: #6c6cff;
 
-  --font-sans: "Inter Variable", system-ui, sans-serif;
-  --font-mono: "JetBrains Mono Variable", ui-monospace, monospace;
+  /* Text & border */
+  --color-fg: #323338;
+  --color-fg-muted: #676879;
+  --color-fg-subtle: #c5c7d0;
+  --color-fg-strong: #1f1f21;
+  --color-border: #d0d4e466;
+  --color-border-solid: #d0d4e4;
+  --color-border-strong: #a8aebb; /* baked darken($border-color, 20%) */
+  --color-border-rail: #8c93a3; /* baked darken($border-color, 30%) */
+  --color-shadow-card: #c3c6d4;
+
+  /* Status / priority labels (Monday palette) */
+  --color-label-green: #00c875;
+  --color-label-green-hover: #0f9b63;
+  --color-label-green-selected: #80e3ba;
+  --color-label-yellow: #ffcb00;
+  --color-label-yellow-hover: #c29e11;
+  --color-label-yellow-selected: #ffe580;
+  --color-label-blue: #579bfc;
+  --color-label-blue-hover: #4c7cc1;
+  --color-label-blue-selected: #abcdfd;
+  --color-label-gray: #c4c4c4;
+  --color-label-gray-hover: #98999a;
+  --color-label-gray-selected: #e1e1e1;
+  --color-label-orange: #fdab3d;
+  --color-label-red: #e2445c;
+  --color-label-purple: #a25ddc;
+  --color-label-pending: #579bfc;
+  --color-label-critical: #333333;
+
+  /* Group accents (12) */
+  --color-group-1: #a25ddc;
+  --color-group-2: #fbbc04;
+  --color-group-3: #f1e4de;
+  --color-group-4: #fdcfe8;
+  --color-group-5: #f28b82;
+  --color-group-6: #fff475;
+  --color-group-7: #ccff90;
+  --color-group-8: #cbf0f8;
+  --color-group-9: #a7ffeb;
+  --color-group-10: #d7aefb;
+  --color-group-11: #e6c9a8;
+  --color-group-12: #e8eaed;
+
+  /* Overlay */
+  --color-overlay: rgba(41, 47, 76, 0.7);
+
+  /* Layout sizes */
+  --size-cell-h: 36px;
+  --size-cell-w: 140px;
+  --size-cell-w-task: 336px;
+  --size-cell-w-checkbox: 32px;
+  --size-cell-w-conversation: 65px;
+  --size-rail-main: 66px;
+  --size-rail-workspace: 230px;
+
+  /* Radii */
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 10px;
+  --radius-pill: 9999px;
+
+  /* Shadows */
+  --shadow-modal: -3px 4px 14px rgb(0 0 0 / 20%);
+  --shadow-drawer: -6px 0px 14px rgb(0 0 0 / 20%);
+  --shadow-card: 0px 4px 8px rgb(0 0 0 / 20%);
+  --shadow-bulk-bar: 0px 15px 50px rgba(0, 0, 0, 0.3);
+
+  /* Z-index layers */
+  --z-base: 0;
+  --z-sticky: 2;
+  --z-rail: 10;
+  --z-board-header: 30;
+  --z-overlay: 50;
+  --z-modal: 51;
+  --z-drawer: 100;
+  --z-popover: 1000;
+
+  /* Motion durations */
+  --motion-instant: 100ms;
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --motion-medium: 300ms;
+  --motion-slow: 400ms;
+  --motion-drawer: 600ms;
+
+  /* Easing */
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-emphasized: cubic-bezier(0.2, 0, 0, 1);
+  --ease-out: cubic-bezier(0, 0, 0.2, 1);
+
+  /* Fonts (set by next/font/google in app/layout.tsx) */
+  --font-sans: var(--font-figtree), "Roboto", "Rubik", system-ui, sans-serif;
+  --font-display: var(--font-poppins), "Roboto", "Rubik", system-ui, sans-serif;
+
+  /* Legacy aliases (deprecated; kept until epic 14 reconciliation). */
+  --color-bg: var(--color-surface);
+  --color-bg-subtle: var(--color-surface-rail);
+  --color-primary-fg: var(--color-primary-foreground);
 }
 
 /*
@@ -78,38 +182,53 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  /* Surfaces */
+  --background: #ffffff; /* was: oklch(1 0 0) */
+  --foreground: #323338; /* was: oklch(0.145 0 0) */
+  --card: #ffffff; /* was: oklch(1 0 0) */
+  --card-foreground: #323338;
+  --popover: #ffffff;
+  --popover-foreground: #323338;
+
+  /* Primary (Monday blue) */
+  --primary: #0073ea; /* was: oklch(0.205 0 0) — neutral gray */
+  --primary-foreground: #ffffff;
+
+  /* Secondary / muted / accent — surface variants */
+  --secondary: #f6f7fb; /* surface-rail */
+  --secondary-foreground: #323338;
+  --muted: #dcdfec; /* surface-hover */
+  --muted-foreground: #676879; /* fg-muted */
+  --accent: #cce5ff; /* surface-active */
+  --accent-foreground: #323338;
+
+  /* Status */
+  --destructive: #e2445c; /* label-red */
+
+  /* Inputs / borders / focus ring */
+  --border: #d0d4e466;
+  --input: #d0d4e466;
+  --ring: #0073ea; /* focus ring = primary */
+
+  /* Charts (placeholders; epic 12 dashboard owns the real palette). Use label palette. */
+  --chart-1: #00c875;
+  --chart-2: #ffcb00;
+  --chart-3: #579bfc;
+  --chart-4: #fdab3d;
+  --chart-5: #a25ddc;
+
+  /* Radius */
+  --radius: 0.25rem; /* was: 0.625rem — Monday cells use 4px corners */
+
+  /* Sidebar (shadcn's sidebar component tokens) */
+  --sidebar: #292f4c; /* surface-nav */
+  --sidebar-foreground: #ffffff;
+  --sidebar-primary: #0073ea;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f6f7fb; /* surface-rail */
+  --sidebar-accent-foreground: #323338;
+  --sidebar-border: #d0d4e466;
+  --sidebar-ring: #0073ea;
 }
 
 .dark {
@@ -149,11 +268,35 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    scrollbar-width: thin;
+    scrollbar-color: #878787 #d9d9d9;
+  }
+  *::-webkit-scrollbar {
+    width: 8px;
+  }
+  *::-webkit-scrollbar-track {
+    background: #d9d9d9;
+  }
+  *::-webkit-scrollbar-thumb {
+    border-radius: 25px;
+    background-color: #a6a5a5;
   }
   body {
     @apply bg-background text-foreground;
+    font-size: 18px;
+    line-height: 1.6;
   }
   html {
     @apply font-sans;
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-display);
+    margin: 0;
+    padding: 0;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,22 @@
 import type { Metadata } from "next";
-import { Geist } from "next/font/google";
+import { Figtree, Poppins } from "next/font/google";
 import { Toaster } from "@/components/ui/sonner";
 import { cn } from "@/lib/utils";
 import "./globals.css";
 
-const geist = Geist({ subsets: ["latin"], variable: "--font-sans" });
+const figtree = Figtree({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-figtree",
+  display: "swap",
+});
+
+const poppins = Poppins({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-poppins",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "Donezo",
@@ -13,7 +25,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning className={cn("font-sans", geist.variable)}>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={cn("font-sans", figtree.variable, poppins.variable)}
+    >
       <body className="bg-bg text-fg antialiased">
         {children}
         <Toaster />

--- a/components/ui/menu-list.tsx
+++ b/components/ui/menu-list.tsx
@@ -1,0 +1,54 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Menu list primitive — the canonical chrome for dropdown menus across the app.
+ *
+ * Implements the legacy @mixin menu-modal() recipe from
+ * frontend/src/assets/styles/setup/_mixins.scss:107-132.
+ *
+ * Usage:
+ *   <MenuList>
+ *     <MenuListItem onClick={...}>Rename</MenuListItem>
+ *     <MenuListItem onClick={...}>Delete</MenuListItem>
+ *   </MenuList>
+ *
+ * Wrap in a <Popover> or <Dialog> for positioning.
+ */
+export function MenuList({ className, children, ...props }: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-0 rounded-md border bg-surface p-2 text-sm text-fg shadow-[var(--shadow-modal)]",
+        "border-[color:var(--color-border-strong)]",
+        "z-[var(--z-popover)]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function MenuListItem({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"button">) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-1 text-left",
+        "hover:bg-surface-hover",
+        "focus-visible:bg-surface-hover focus-visible:outline-none",
+        "disabled:opacity-50 disabled:cursor-not-allowed",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/docs/conversion-plan/00-overview.md
+++ b/docs/conversion-plan/00-overview.md
@@ -6,7 +6,16 @@ The goal is a credible monday.com-class internal tool. Billing, tenant isolation
 
 ## Why this plan exists
 
-The audit at [`docs/audit/`](../audit/00-index.md) inventories the legacy codebase and concludes that a structural rebuild beats incremental fixes ([decision memo](../audit/11-recommendation-migrate-now.md)). This conversion plan is the execution of that decision. We are not porting code — we are rebuilding on the right substrate, salvaging only the visual design and product knowledge.
+The audit at [`docs/audit/`](../audit/00-index.md) inventories the legacy codebase and concludes that a structural rebuild beats incremental fixes ([decision memo](../audit/11-recommendation-migrate-now.md)). This conversion plan is the execution of that decision. We are not porting code — we are rebuilding on the right substrate.
+
+**Visual fidelity is a hard contract, not aspirational.** The legacy CRA + SCSS + MUI frontend at `frontend/` (kept locally per [CLAUDE.md](../../CLAUDE.md)) is the single source of truth for color, typography, spacing, motion, and component visuals. The new app must match it. Rebuilding "on the right substrate" means new code (Next.js, Supabase, Tailwind, shadcn/ui) — it does **not** mean a new visual identity.
+
+The locked specs are:
+
+- **[`design-system.md`](design-system.md)** — every color, font, spacing value, radius, shadow, z-index, motion duration, and icon mapping, sourced verbatim from `frontend/src/assets/styles/setup/_variables.scss` and the SCSS partials. Includes the canonical `app/globals.css` `@theme` block.
+- **[`component-system.md`](component-system.md)** — every significant legacy component's visual + interaction contract, mapped to the epic that ships it and tagged with a fidelity bar (`must-match` / `match` / `inspired`).
+
+Every epic that touches UI references these docs in a "Visual fidelity requirements" section. Executors must consume tokens from `design-system.md` and component contracts from `component-system.md`; they may not invent palettes, derive new spacing, or pick alternative icons. Architectural deviations escalate to the `epic-researcher` (Opus), as with any other ambiguity.
 
 ## Target stack
 
@@ -14,7 +23,7 @@ The audit at [`docs/audit/`](../audit/00-index.md) inventories the legacy codeba
 |---|---|---|
 | Framework | **Next.js 15 (App Router)** | RSC + server actions remove the bespoke REST layer. File-based routing, middleware, edge runtime, image optimization, built-in caching. |
 | Language | **TypeScript (strict)** | No untyped service modules, no `any`-typed Redux state. Generated Supabase types enforce DB shape end-to-end. |
-| UI | **Tailwind v4 + shadcn/ui + Radix primitives** | Replace MUI + SCSS. Tokens-driven theming, accessible primitives, consistent component vocabulary. Drops ~600KB of MUI. |
+| UI | **Tailwind v4 + shadcn/ui + Radix primitives** | Replace MUI + SCSS. Tokens-driven theming, accessible primitives, consistent component vocabulary. Drops ~600KB of MUI. Tokens locked in [`design-system.md`](design-system.md); component contracts in [`component-system.md`](component-system.md). |
 | Forms | **React Hook Form + Zod** | One schema validates client and server-action inputs. |
 | Tables | **TanStack Table + TanStack Virtual** | Virtualized rows for 10k+ task boards. Headless, fully styleable. |
 | DnD | **dnd-kit** | Replaces abandoned `react-beautiful-dnd`. Touch-capable. Nested drop zones for kanban. |
@@ -37,6 +46,7 @@ The audit at [`docs/audit/`](../audit/00-index.md) inventories the legacy codeba
 
 These shape every epic. When in doubt, return to these.
 
+0. **Visual fidelity is a contract.** Tokens come from [`design-system.md`](design-system.md). Component contracts come from [`component-system.md`](component-system.md). Both are sourced from the legacy `frontend/` SCSS. No "neutral" palette, no "we'll polish later," no inventing tokens during slice work. If a component looks different from the legacy app's screenshot, it's wrong.
 1. **RSC-first.** Default to Server Components. Drop to `"use client"` only for interactivity (drag, picker popovers, optimistic UI). Server Actions handle mutations; no `/api` route handlers unless we need a webhook or third-party integration.
 2. **RLS is the source of truth for authorization.** The server cannot trust the client, but it also doesn't need to: every query goes through Postgres with the user's JWT, and policies enforce access. Server-side checks are a defense-in-depth layer, not the primary gate.
 3. **Type-safe end-to-end.** `supabase gen types typescript` runs on every schema change. Server actions accept Zod-validated input. Component props are narrow.
@@ -125,6 +135,8 @@ The order is not negotiable for the foundation epics. Feature epics (05+) are mo
 
 ```
 00 Overview (you are here)
+   design-system.md   ← consumed by every UI epic
+   component-system.md
 ↓
 01 Foundation ──────────┐
                         ↓
@@ -181,6 +193,7 @@ A board where:
 - Audit log export, compliance modes (SOC2/HIPAA)
 - Public form sharing beyond authenticated users (form view exists; public sharing deferred)
 - Cross-board mirror/dependency cell types (column types listed but stubbed in [07](07-column-system.md))
+- **Marketing / public landing page.** The only public route is the Google sign-in screen ([03](03-auth.md)). The legacy `cmps/home/` + `cmps/custom/` components are not ported; the marketing-only tokens (brand-violet gradients, home-page hero gradient) are not ported either. See [`design-system.md`](design-system.md) and [`component-system.md`](component-system.md).
 
 ## How to read each epic doc
 
@@ -192,9 +205,10 @@ Every epic doc follows the same shape:
 4. **Dependencies** — which earlier epics must be merged.
 5. **Architecture & design choices** — the substantive section. Every nontrivial decision documented with rationale.
 6. **Schema additions / migrations** — SQL where relevant.
-7. **Tasks** — checklist, ordered. Each task is a half-day to two-day chunk.
-8. **Definition of done** — testable criteria.
-9. **Open questions** — things to resolve before starting or during.
+7. **Visual fidelity requirements** (UI epics only) — points at [`design-system.md`](design-system.md) and [`component-system.md`](component-system.md), enumerates the components this epic must match and the tokens it must consume.
+8. **Tasks** — checklist, ordered. Each task is a half-day to two-day chunk.
+9. **Definition of done** — testable criteria.
+10. **Open questions** — things to resolve before starting or during.
 
 ## Conventions
 

--- a/docs/conversion-plan/01-foundation.md
+++ b/docs/conversion-plan/01-foundation.md
@@ -72,35 +72,23 @@ We do **not** plan to use React Server Actions for everything. Long-lived subscr
 
 Tailwind v4 uses CSS-native config (no `tailwind.config.ts` for tokens) — design tokens live in `app/globals.css` under `@theme`. shadcn components are copied into `components/ui/` (not installed as a package), giving us full ownership.
 
-Design tokens (initial set, expand as features need them):
+**Tokens are not "initial — expand as needed."** The full token set is locked in [`design-system.md`](design-system.md), sourced verbatim from the legacy `frontend/` SCSS (see CLAUDE.md). The `@theme` block in `app/globals.css` MUST be the canonical block from [design-system.md §1.2](design-system.md#12-appglobalscss-block-canonical) — Monday-derived blue/navy/yellow/green palette plus brand-violet marketing gradients, plus the bake-out of SCSS `darken()` calls. Do not invent tokens or use a generic "neutral" palette.
 
-```css
-@theme {
-  --color-bg: oklch(99% 0 0);
-  --color-bg-subtle: oklch(97% 0 0);
-  --color-fg: oklch(20% 0 0);
-  --color-fg-muted: oklch(45% 0 0);
-  --color-border: oklch(92% 0 0);
-  --color-primary: oklch(58% 0.2 260);
-  --color-primary-fg: oklch(99% 0 0);
-  --color-danger: oklch(60% 0.22 25);
-  --color-success: oklch(62% 0.18 145);
-  --color-warning: oklch(75% 0.16 75);
+Fonts: load **Figtree** (body) and **Poppins** (display) via `next/font/google` per [design-system.md §2.1.1](design-system.md#211-loader-nextjs-in-applayouttsx). Replace the SCSS `Figtree-Regular.ttf` / `Poppins-Regular.ttf` shipped in legacy with the variable subsets; do not use the legacy single-weight TTFs.
 
-  --radius-sm: 0.25rem;
-  --radius-md: 0.5rem;
-  --radius-lg: 0.75rem;
-
-  --font-sans: 'Inter Variable', system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono Variable', ui-monospace, monospace;
-}
-```
+Scrollbar styles, overlay color, z-index layers, motion duration tokens, and radii are also locked in [design-system.md](design-system.md). Lift them all into `globals.css` in this epic.
 
 Dark mode via `next-themes` ([14](14-mobile-a11y-polish.md)) — tokens get `[data-theme="dark"]` overrides later. Avoid hex literals in components; reference tokens.
 
 ### shadcn install set (initial)
 
 `button`, `input`, `textarea`, `label`, `select`, `dropdown-menu`, `popover`, `dialog`, `sheet`, `tooltip`, `command`, `avatar`, `badge`, `separator`, `skeleton`, `toast` (sonner), `tabs`, `scroll-area`, `checkbox`, `switch`, `form` (RHF wrapper). Install on demand, not all at once.
+
+Each shadcn primitive lands **already wired to the locked tokens**. The default `button.tsx` shipped by shadcn uses generic `bg-primary` etc. — we keep those class names, but the `--color-primary` value is the Monday `#0073ea`. Re-skin none, restyle none unless [`component-system.md`](component-system.md) calls for a deviation.
+
+### Icon library
+
+Single source: **Lucide React** (`lucide-react`). Establish `lib/icons.ts` re-exporting the named subset we use, with the legacy `react-icons` mapping documented in [design-system.md §9.2](design-system.md#92-mapping-table). No imports from `@mui/icons-material` or `react-icons` in new code.
 
 ### Linting & formatting
 
@@ -211,15 +199,35 @@ For epic 01, scaffold the helper signature even though there's no auth yet — p
 
 Recommended for cell renderers ([07](07-column-system.md)). If we install it, do it now in epic 01 so the configuration is in place. Storybook 8 with the Vite builder. If we skip, document the decision.
 
+## Visual fidelity requirements
+
+This epic owns the design-system foundation. Every token, font, scrollbar style, overlay color, z-index, and icon library that downstream epics will reference must land here. Source: [`design-system.md`](design-system.md), [`component-system.md`](component-system.md).
+
+Must-match items (any drift breaks every later epic):
+
+- The **canonical `@theme` block** from [design-system.md §1.2](design-system.md#12-appglobalscss-block-canonical), including Monday primary `#0073ea`, sidebar navy `#292f4c`, label palette (`#00c875`, `#ffcb00`, `#579bfc`, `#c4c4c4`, `#FDAB3D`, `#E2445C`, `#A25DDC`, `#333333`), 12-color group accents, and brand-violet marketing gradients (`#5034FF → #B4B4FF`).
+- **Figtree** body + **Poppins** display via `next/font/google`, weights 400/500/600/700.
+- Custom **scrollbar** styles per [design-system.md §10](design-system.md#10-scrollbar) (8px, `#A6A5A5` thumb on `#D9D9D9` track).
+- **z-index layer** custom properties (`--z-base/sticky/rail/board-header/overlay/modal/drawer/popover`) per [§7](design-system.md#7-z-index-layers).
+- **Motion duration** tokens (`--motion-instant/fast/base/medium/slow/drawer`) per [§8.1](design-system.md#81-duration-tokens).
+- **Lucide React** wired in `lib/icons.ts`. No `@mui/*` or `react-icons` imports anywhere in the repo.
+- **`<MenuList />` primitive** matching the legacy `@mixin menu-modal` recipe — see [component-system.md §3.2](component-system.md#32-menumodal-recipe-mixin).
+- **`<Logo />`** matching [component-system.md §6.2](component-system.md#62-logo) (PNG fallback acceptable; SVG preferred).
+
+If the executor wants to swap a hex/value for a different one, they must escalate via `epic-researcher` — these are not negotiable in slice work.
+
 ## Tasks
 
 1. **Initialize Next.js project.** `pnpm create next-app@latest` with TypeScript, Tailwind, App Router, Biome (or eslint→biome migration). Confirm Node 22 with `.nvmrc`.
 2. **Configure TypeScript strict.** Replace generated `tsconfig.json` with the strict version from this doc.
-3. **Set up Tailwind v4 design tokens.** Replace generated `globals.css` with `@theme` block. Verify `bg-bg`, `text-fg`, etc. classes work.
-4. **Initialize shadcn/ui.** `pnpm dlx shadcn@latest init`. Install the initial component set listed above.
+3. **Set up Tailwind v4 design tokens.** Replace generated `globals.css` with the canonical `@theme` block from [design-system.md §1.2](design-system.md#12-appglobalscss-block-canonical). Add the scrollbar styles from §10. Verify `bg-surface`, `text-fg`, `bg-primary`, `bg-surface-nav` etc. classes work.
+4. **Initialize shadcn/ui.** `pnpm dlx shadcn@latest init`. Install the initial component set listed above. Verify the default `<Button variant="default">` renders with `--color-primary` (`#0073ea`).
 5. **Configure Biome.** Single `biome.json`. Add the rules listed above. Wire to `lint` script.
 6. **Add environment validator.** `lib/env.ts` per spec. Add `.env.example` with stubbed `NEXT_PUBLIC_SUPABASE_URL` etc. — values land in [02](02-supabase-schema.md).
 7. **Scaffold repository structure.** Create the empty folder layout from [`00-overview.md`](00-overview.md). `.gitkeep` files in empty folders.
+7a. **Wire fonts.** Add `next/font/google` loaders for Figtree (body) and Poppins (display) per [design-system.md §2.1.1](design-system.md#211-loader-nextjs-in-applayouttsx). Apply `--font-display` to `h1`–`h6` in `globals.css`.
+7b. **Add icon module.** `pnpm add lucide-react`. Create `lib/icons.ts` re-exporting the names from [design-system.md §9.2](design-system.md#92-mapping-table). Forbid raw `lucide-react` imports outside this module via Biome rule.
+7c. **Add `<MenuList />` primitive.** Implement the `@mixin menu-modal` recipe from [component-system.md §3.2](component-system.md#32-menumodal-recipe-mixin) as `components/ui/menu-list.tsx`. Used by every dropdown across the app.
 8. **Create error/404 pages.** Global and segment-scoped error boundaries, 404 page, both styled.
 9. **Add logger module.** Pino + pino-pretty in dev. Confirm log output.
 10. **Add server-action helper stub.** `lib/actions/with-user.ts` returning a synthetic user. Document the contract.

--- a/docs/conversion-plan/05-workspaces-boards.md
+++ b/docs/conversion-plan/05-workspaces-boards.md
@@ -200,6 +200,25 @@ alter table public.profile
 alter table public.column add column icon text;
 ```
 
+## Visual fidelity requirements
+
+This epic stands up the app shell and is the first to render Donezo's chrome to a logged-in user. Every component below has a locked spec in [`component-system.md`](component-system.md). Source tokens from [`design-system.md`](design-system.md) — never invent new values.
+
+Must-match components (review screenshots before merge):
+
+- **`<MainSidebar />`** — bg `--color-surface-nav` (`#292f4c`), 66px wide rail, hover wash `rgba(0,0,0,.6)` with 10px radius. Avatar `scale(.9)` on hover. Mobile bottom-bar variant per [component-system.md §1.1](component-system.md#11-mainsidebar-icon-column).
+- **`<WorkspaceSidebar />`** — bg `--color-surface-rail` (`#F6F7FB`), `230px` open / `30px` collapsed. Width animates over `--motion-slow`; inner content opacity fades `0 → 1` with **0.25s delay** so it appears after the rail finishes. Toggle pill on right edge animates padding asymmetrically on hover. See [§1.2](component-system.md#12-workspacesidebar-slide-out-workspace-panel).
+- **`<BoardHeader />`** — sticky bar with title (inline-editable per [§2.1](component-system.md#21-inline-editable-title-blockquote-pattern)), star (`--color-label-yellow` filled), board tools row, member avatar pile (24px, `-5px` overlap, white border), view tabs (only "Table" enabled in this epic; active tab gets 2px bottom border `--color-primary`). See [§1.3](component-system.md#13-boardheader-top-of-board).
+- **`<CreateBoardModal />`** — 500px wide centered modal with `--shadow-modal`. See [§3.7](component-system.md#37-createboardmodal-centered).
+- **`<MemberModal />` / `<InviteModal />`** — 360px panel, member chips bg `--color-chip-member` (`#e5f4ff`), radius `8px`. See [§3.8](component-system.md#38-membermodal--invitemodal).
+- **`<BoardDescriptionModal />`** — 850×550 two-pane modal with right pane bg `--color-surface-info`. See [§3.6](component-system.md#36-boarddescriptionmodal-centered-two-pane).
+- **Active board row** in workspace sidebar uses `--color-surface-active` (`#cce5ff`).
+- **Workspace logo glyph** — 30×30 rounded-8px tile bg `--color-label-green` with white "lightning" + home overlay. See [§1.2](component-system.md#12-workspacesidebar-slide-out-workspace-panel).
+- **Favorites empty-state** — 80px star, line-height 1.5. See [§8.3](component-system.md#83-favorites-empty-state).
+- **`<LastViewed />`** workspace landing widget — see [§8.2](component-system.md#82-lastviewed).
+
+Inline-editable title pattern ([component-system.md §2.1](component-system.md#21-inline-editable-title-blockquote-pattern)) ships its first instance here on the board title — extract as a shared `<EditableTitle />` primitive, since [06](06-groups-tasks-table.md) (group + task) and [09](09-comments-activity.md) (board description) all reuse it.
+
 ## Tasks
 
 1. **Migration** for `profile.last_workspace_id` and `column.icon`.

--- a/docs/conversion-plan/06-groups-tasks-table.md
+++ b/docs/conversion-plan/06-groups-tasks-table.md
@@ -284,6 +284,26 @@ A subtle issue: when *we* mutate, we'll receive our own Realtime echo. Idempoten
 - No tasks in group: lighter-weight inline message under the group header: "No tasks yet — add one below."
 - Filtered to nothing ([11](11-filtering-views.md)): "No tasks match the current filter. Clear filter."
 
+## Visual fidelity requirements
+
+This epic delivers the core "Monday-feel" of the table view. The components below are the most visible part of the product; every one is locked in [`component-system.md`](component-system.md) and its tokens in [`design-system.md`](design-system.md).
+
+Must-match (this epic must produce something that *feels* like a Monday board, not just a styled HTML table):
+
+- **`<GroupHeader />`** — sticky at `top: 182px` (narrow+) / `149px` (mobile). Title H4 weight 600, 18px, color = group accent (`--color-group-N`). Task count fades in `0 → 1` on hover over `--motion-base`. Overflow menu glyph (`MoreHorizontal` 20px) in off-canvas left column, hidden by default. See [component-system.md §2.2](component-system.md#22-groupheader).
+- **`<TaskRow />`** — 36px tall. Sticky-div on the left with `border-left: 6px solid <group-accent>` (the **group color stripe** is locked — it's how rows visually belong to a group). Drag handle, checkbox (33px), title cell (336px), comment count badge (`14×13` circle bg `--color-primary`). Row hover reveals drag handle + Open expand affordance + comment-add icon over `--motion-base`. See [§2.3](component-system.md#23-taskrow--taskpreview).
+- **Inline-editable title** for group + task — same `<EditableTitle />` pattern from [05](05-workspaces-boards.md). When editing, the row gets the **"on-typing" wash** (`bg: --color-surface-active`, `#cce5ff`) so collaborators perceive a live edit. See [component-system.md §2.1](component-system.md#21-inline-editable-title-blockquote-pattern).
+- **"+ New Item" split-button** — bg `--color-primary`, 32px tall, radius 5px. Two halves with independent corner-rounding on hover, divider in `--color-primary-hover`. Lock the split-button visual contract — it's the toolbar's primary anchor. See [§1.4](component-system.md#14-boardfilter-toolbar) (full filter toolbar lands in [11](11-filtering-views.md), but the split-button itself ships here).
+- **`<BulkActionBar />`** — floating fixed-bottom bar that slides in over `--motion-fast` when ≥1 task is selected. Count tile bg `--color-primary` 63px wide, body padding `0 20px`, action buttons icon-on-top with 18px glyph + 12px label, hover glyph color `--color-primary`. See [§3.9](component-system.md#39-bulkactionbar-floating).
+- **Group color stripe + `<ColorPalette />`** popover — 142px wide grid of 12 swatches from `--color-group-1` through `--color-group-12`. See [§3.3](component-system.md#33-colorpalette-popover).
+- **Group menu, task menu, add-group modals** — all use the `<MenuList />` recipe from [01](01-foundation.md). No bespoke chrome.
+- **Cell skeleton** — 140px min-width, 36px height, `1px solid --color-border-strong` border. Title cell only is filled in this epic; other cells stub to a placeholder of identical chrome.
+
+Motion notes:
+- Row hover reveals (`task-menu`, `open-task-details`, comment-add): `opacity 0 → 1` over `--motion-base`.
+- "+ New Item" hover bg shift: `--motion-slow` (`.4s`).
+- Bulk-bar slide-in: `--motion-fast` (150ms).
+
 ## Tasks
 
 1. **Set up TanStack Table + Virtual + dnd-kit deps.** `pnpm add @tanstack/react-table @tanstack/react-virtual @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities`.

--- a/docs/conversion-plan/07-column-system.md
+++ b/docs/conversion-plan/07-column-system.md
@@ -350,6 +350,47 @@ In addition to those from [06](06-groups-tasks-table.md):
 
 Each cell type has stories: empty, populated, in-edit-mode, with config variations. This is the single best argument for keeping Storybook ([01](01-foundation.md) open question).
 
+## Visual fidelity requirements
+
+This is the epic where every cell type in the registry gets its visual contract. Cells are 90% of the board's surface area — fidelity here is the difference between "looks like Monday" and "looks like a styled HTML table." Refer to [`component-system.md §2.4`](component-system.md#24-cell-components-per-type) for the per-type table.
+
+Must-match across all cell types:
+
+- **Cell skeleton** — `min-width: 140px`, `height: 36px`, `1px solid --color-border-strong` border. Don't deviate.
+- **Focus state** — `outline: 1px solid --color-primary` (`#0073ea`) on inputs and contenteditable cells. Hover preview uses `outline: 1px solid --color-border-strong`.
+- **Optimistic update** with no in-flight chrome — cells flick to the new value instantly; no spinner.
+
+Per-type must-matches:
+
+- **`<StatusCell />` / `<PriorityCell />`** — full-bleed bg = label color, centered white label text, **diagonal "fold" reveal in top-right on hover**. The fold animates `border-width 0 → 10×10 → 15×15px` over `--motion-base` with `transition-delay: .2s`. This is the single most distinctive interaction in the product — must match. Empty state bg `--color-label-gray` (`#c4c4c4`). See [_status-priority-picker.scss:6-28](../../frontend/src/assets/styles/cmps/task-picker/_status-priority-picker.scss).
+- **`<StatusLabelEditor />` popover** — 152px-wide chips, gap 8px, white-text-on-color, "Edit Labels" button at bottom with `1px solid --color-border-strong` top border. See [component-system.md §3.4](component-system.md#34-statuslabeleditor-popover).
+- **`<PersonCell />`** — 26px avatars, `-5px` overlap, white border, `+N` overflow tile. Empty state shows muted person glyph in `--color-fg-subtle`.
+- **`<DateCell />`** — centered text input, hover text → `--color-primary`, focus border `--color-primary`.
+- **`<NumberCell />`** — centered numeric input, hover reveals `+`/`−` icons in `--color-primary` and a `clear` chip top-right (bg `--color-surface-hover`, radius 3px) over `--motion-base`.
+- **`<CheckboxCell />`** — centered icon, checked = `--color-primary`, hover wash `rgba(0,0,0,0.05)` over `--motion-base` (note: checked state is **primary blue**, not green).
+- **`<UpdatedByCell />`** — 26px avatar + relative-time string (`2h`, `5d`, `3w`) computed via the legacy `calculateTime` algorithm.
+- **All other cell types** (`text`, `long_text`, `email`, `phone`, `country`, `link`, `tags`, `rating`, `currency`, `vote`, `week`, `location`, `formula`, `created_by`, `created_at_col`) — inherit the cell skeleton, follow the picker patterns above for editor chrome, use `<MenuList />` for any dropdowns.
+
+Default seed labels (these must match exactly — they're the user's first impression of the system):
+
+| Type | Title | Color |
+|---|---|---|
+| Status | Done | `#00C875` |
+| Status | Working on it | `#FDAB3D` |
+| Status | Stuck | `#E2445C` |
+| Status | Waiting for review | `#A25DDC` |
+| Status | Pending | `#579BFC` |
+| Status | (empty) | `#C4C4C4` |
+| Priority | Critical | `#333333` |
+| Priority | High | `#E2445C` |
+| Priority | Medium | `#FDAB3D` |
+| Priority | Low | `#579BFC` |
+| Priority | (empty) | `#C4C4C4` |
+
+These must be inserted in the [02](02-supabase-schema.md) seed; this epic relies on them existing.
+
+**Aggregation row** at group footer: typography 14px (font-weight 500 for the number, 12px for "sum" sub-label in `--color-fg-muted`). See [_group-statistics.scss](../../frontend/src/assets/styles/cmps/group/_group-statistics.scss).
+
 ## Tasks
 
 1. **Define the `CellTypeDef` interface** in `lib/cells/types.ts` with full TS strictness.

--- a/docs/conversion-plan/09-comments-activity.md
+++ b/docs/conversion-plan/09-comments-activity.md
@@ -254,6 +254,21 @@ The cleanest pattern: every server action emits `(activity, [notifications])` to
 
 Each comment has an id; the task drawer URL accepts `?comment=<id>` to scroll-to and highlight. Useful for email links from notifications.
 
+## Visual fidelity requirements
+
+This epic ships the right-side **task drawer** (the third "monday-feel" surface after the sidebar and the table), the comment thread, and the activity feed. Specs in [`component-system.md`](component-system.md), tokens in [`design-system.md`](design-system.md).
+
+Must-match:
+
+- **`<TaskDrawer />`** — fixed right-side drawer, `min-width: 570px` desktop / 100vw mobile. Slide-in `transform: translateX(100% → 0)` over `--motion-drawer` (`.6s`); drawer shadow `--shadow-drawer`. Header at 53px tall, font 18px. Tab strip with `1px solid --color-border` bottom and active tab indicated by `2px solid --color-primary` underline. Content scrolls 85vh with hidden scrollbar. See [§3.5](component-system.md#35-taskdrawer-right-slide-modal).
+- **Update editor card** — outline `1px solid --color-primary`, radius 4px, height 145px. Save button bg `--color-primary`, white text, height 32px, radius 4px. See [_board-modal.scss:84-129](../../frontend/src/assets/styles/cmps/modal/_board-modal.scss).
+- **`<CommentItem />`** — `1px solid --color-border-strong` border, radius 4px, padding 16px, margin-bottom 16px. Header avatar 26px, name 16px in `--color-fg`, timestamp/menu glyph row in `--color-fg-muted`. Body padding `0 16px 16px`. See [§4.1](component-system.md#41-commentlist--commentitem).
+- **`<ActivityItem />`** — 60px row, padding `8px 0`, `1px` bottom border `--color-shadow-card`, font 16px (mobile 12px). Activity labels render with the cell's status-color bg + white text + 4px radius (matching the status pill chrome). See [§4.2](component-system.md#42-activitylist--activityitem).
+- **Inline editable description** for board description — uses the [§2.1 blockquote pattern](component-system.md#21-inline-editable-title-blockquote-pattern).
+- **Mention chips** in the editor — should follow the chip pattern: bg `--color-chip-member` (`#e5f4ff`), radius 8px, gap 8px.
+
+Activity payload renderers consume the cell registry from [07](07-column-system.md), so status/priority changes render with the same colored pill as the cell — this is part of the visual contract, not just a code-reuse choice.
+
 ## Tasks
 
 1. **Add `comment_reaction` table** in a migration. RLS + publication.

--- a/docs/conversion-plan/11-filtering-views.md
+++ b/docs/conversion-plan/11-filtering-views.md
@@ -261,6 +261,20 @@ alter table public.profile
 
 The `view` table itself was created in [02](02-supabase-schema.md). The default-view insertion happens in [05](05-workspaces-boards.md)'s `createBoard` server action — update it to insert "Main table" automatically (already noted in [05](05-workspaces-boards.md)'s tasks).
 
+## Visual fidelity requirements
+
+This epic completes the `<BoardFilter />` toolbar started in [06](06-groups-tasks-table.md) and adds saved-view tabs. Refer to [`component-system.md §1.4`](component-system.md#14-boardfilter-toolbar) and [`design-system.md`](design-system.md).
+
+Must-match:
+
+- **`<BoardFilter />` toolbar full** — gap 5px, each tool 32px tall, font 14px. Tools (`Person`, `Filter`, `Sort`, `Hide`, `Group`, `Search`): padding `0 8px`, color `--color-fg-muted`, glyph 18px. Hover bg `--color-surface-hover`, radius 4px.
+- **Search expand animation** — input width `58 → 140px` over `--motion-medium` on focus. Chrome border on focus `0.5px --color-primary`, bg white. Cursor flips `pointer → text` on focus. See [_board-filter.scss:90-110](../../frontend/src/assets/styles/cmps/board/_board-filter.scss).
+- **Person filter chip active state** — bg `--color-primary-selected` (`#cce5ff`), radius 4px.
+- **`<ViewTabs />`** — same chrome as board view tabs: 32px tall, padding `0 8px`, font 14px weight 500. Active tab gets 2px bottom border `--color-primary`. Inactive hover bg `--color-surface-hover`, radius `4px 4px 0 0`.
+- **`<FilterBuilder />` popover** — uses `<DynamicModal />` chrome from [01](01-foundation.md): bg white, border `1px solid --color-border-strong`, radius 8px, shadow `--shadow-modal`, z-index `--z-popover`.
+- **`<GlobalSearchPalette />` (Cmd-K)** — modal centered, ~640px wide, radius `--radius-md`, shadow `--shadow-modal`. Each result row uses the `<MenuList />` recipe.
+- **Filter operand editors** — reuse the cell-type editors in compact mode (don't redesign per filter type).
+
 ## Tasks
 
 1. **Migration**: `profile.last_view_per_board`.

--- a/docs/conversion-plan/12-alternate-views.md
+++ b/docs/conversion-plan/12-alternate-views.md
@@ -196,6 +196,27 @@ Stored in the view's config. Editor: a panel in the view settings.
 - Map view, Workload view, Files view, Chart per group: all stubbed in the "+ Add view" dropdown with a "Coming soon" tooltip; not added in v1.
 - Form public sharing: similar.
 
+## Visual fidelity requirements
+
+This epic spans five different views; each needs to feel cohesive with the table while having its own visual rhythm. Tokens always come from [`design-system.md`](design-system.md); component contracts in [`component-system.md`](component-system.md).
+
+**Must-match — Kanban** ([component-system.md §7.1](component-system.md#71-kanbanboard-lanes--cards)):
+- Lane width `260px`, bg `--color-surface-rail` (`#F6F7FB`).
+- Lane header 44px tall, white text on group color, top corners `8px` rounded.
+- Card bg white, radius 4px, shadow `--shadow-card` (`0px 4px 8px rgb(0 0 0 / 20%)`), font 13px, margin-bottom 8px.
+- Card title row 36px, gap 4px, with chat icon right (24px) + comment count badge (`14×13` circle, bg `--color-primary`).
+- Card content rows: stacked picker rows, each 36px tall with bg `--color-surface-info` (`#f5f6f8`).
+- Lane container max-height `410px`, flex-wrap.
+
+**Match — Calendar / Timeline / Dashboard / Form**:
+- Use `--color-primary` for selected dates and active timeline today-line.
+- Status-pill bars in Timeline use the cell registry's color palette (no new color choices).
+- Dashboard widgets: 2px border `--color-border-strong` with hover border-color `--color-primary` (per [_dashboard.scss:14](../../frontend/src/assets/styles/views/_dashboard.scss)). Widget headers separated by `1px solid --color-border-strong`.
+- Form view inputs reuse the chrome from [03](03-auth.md) auth forms (radius 4px, padding `8px 16px`, focus border `--color-primary`).
+- Card style applied to `<TaskCard />` for kanban/calendar/timeline must come from a single shared renderer — same component, three contexts.
+
+Use the `<MenuList />` primitive for any dropdowns (group-by picker, density toggle, view-tab dropdown). Don't roll bespoke menus per view.
+
 ## Tasks
 
 ### Shared

--- a/docs/conversion-plan/14-mobile-a11y-polish.md
+++ b/docs/conversion-plan/14-mobile-a11y-polish.md
@@ -252,6 +252,23 @@ A coordinated review pass over:
 - **Storybook** (if used): visual regression via Chromatic or Percy.
 - **Playwright visual snapshots**: capture key screens at three viewports (mobile/tablet/desktop) per PR.
 
+## Visual fidelity requirements
+
+This epic adds dark mode, mobile responsive parity, and a polish pass — none of it should re-derive tokens. Pull from [`design-system.md`](design-system.md) and [`component-system.md`](component-system.md) only.
+
+Must-match:
+
+- **Dark mode tokens** — derive from the locked light tokens (don't reinvent the palette). Recommended approach in [design-system.md §1.1.7](design-system.md#117-overlay--misc): invert `--color-fg`/`--color-surface`, dial label saturation back ~10%, keep `--color-primary` close to `#0073ea`. Apply via `[data-theme="dark"]` overrides on `:root`.
+- **Mobile `<MainSidebar />`** — fixed-bottom row at `8vh` height, gap `30px`, hidden tools, hamburger reveals workspace sidebar full-width. See [component-system.md §1.1](component-system.md#11-mainsidebar-icon-column) (mobile contract documented there).
+- **Mobile `<WorkspaceSidebar />`** — open state takes 100vw; toggle pill hidden.
+- **Reduced motion** — `@media (prefers-reduced-motion: reduce)` overrides any animation longer than `--motion-base` (200ms) to `0ms`. Critically: the workspace-sidebar collapse, board drawer slide-in, and status-fold reveal all need this guard.
+- **Skeleton states** — replace the legacy `loader.gif` everywhere with shadcn `<Skeleton />`. Match the ~36px row height for table skeletons so the page doesn't shift layout on hydration.
+- **`<EmptyState />` primitive** — used in trash, no-boards, no-tasks-in-group, favorites-empty. Lock typography: title font-display 24px weight 500, body 14px in `--color-fg-muted`, CTA = primary button.
+- **Color contrast** — every label color in [§1.1.5](design-system.md#115-status--priority-palette-monday-colors) must hit WCAG AA against white text. The orange (`#FDAB3D`) and yellow (`#ffcb00`) labels carry **black** text in legacy at certain sizes — verify.
+- **Animation pass** — all micro-interactions from [§8.3](design-system.md#83-recurring-micro-interaction-patterns) must work after the polish pass; if any have regressed, fix here.
+
+Don't introduce new tokens here. Only consume.
+
 ## Tasks
 
 ### Mobile

--- a/docs/conversion-plan/_dispatch/epic-01-followup-2.md
+++ b/docs/conversion-plan/_dispatch/epic-01-followup-2.md
@@ -1,0 +1,602 @@
+# Epic 01 — Followup Round 2 (Design-System Retrofit)
+
+**Status:** approved, ready to dispatch
+**Triggered by:** Locked-down design system docs ([`design-system.md`](../design-system.md), [`component-system.md`](../component-system.md)).
+**Branch:** `epic/01-followup-design-system` (off current `main`)
+**Reviewer verdict (this round):** N/A — this is a forward-spec, not a fix-up.
+
+## Why this round exists
+
+Epic 01 shipped foundation tokens as **placeholder OKLCH neutrals** (per `01-foundation.md`'s "initial set, expand as features need them" line). After the visual-fidelity audit, that contract was upgraded: tokens are now sourced **verbatim from the legacy `frontend/` SCSS** (Monday-derived blue/navy/yellow/green palette + 12 group accents + label palette + motion/z-index/shadow tokens). See [00-overview.md](../00-overview.md) and the locked specs.
+
+This round retrofits epic 01's substrate with those tokens **before any UI epic (05+) starts**, so subsequent UI work consumes the canonical chrome and doesn't have to be re-skinned later.
+
+## Decisions made by user (locked)
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Keep dual `@theme` blocks (spec + shadcn) or unify? | **Keep both.** Per epic-01-followup-1 decision #1, unification defers to epic 14. This round updates **values** in both blocks; structure stays. |
+| 2 | Token name reconciliation between spec (`--color-bg/fg/border`) and design-system.md (`--color-surface/fg/border`) | **Keep both names.** Add design-system.md tokens as the new canonical set; keep legacy aliases (`--color-bg`, `--color-primary-fg`) as synonyms so existing usages in `app/page.tsx` etc. don't break. Comment them as deprecated; remove in epic 14. |
+| 3 | Marketing tokens / fonts | **Drop entirely.** No brand-violet, no home gradients, no Poppins-on-marketing. Poppins still loads for `h1`–`h6` because legacy `_base.scss` applied it app-wide. |
+| 4 | Group-color palette user-pickable? | **Yes, locked to the 12 colors** from `util.service.js:65`. Exposed as `--color-group-1` … `--color-group-12`. Component code reads from tokens; users cannot free-pick. (Schema already enforces — labels store hex from a closed set.) |
+| 5 | Icon discipline (no `react-icons`, no `@mui/icons-material`) | **Lock at the doc level**, not Biome. `lib/icons.ts` is the canonical re-export; reviewers police direct `lucide-react` imports during code review. (Adding a Biome rule for this would touch `biome.json`, which is a forbidden-scope file per epic-01-followup-1; we don't need automation here.) |
+| 6 | Order of slice work | **Two parallel slices, disjoint file scope.** Slice I = `globals.css` + `app/layout.tsx` (substrate). Slice J = `lib/icons.ts` + `components/ui/menu-list.tsx` (additive primitives). |
+
+## Issues being addressed
+
+- **Visual fidelity contract drift.** Without this retrofit, every UI epic from 05 onward would either re-derive tokens (drift) or build against placeholders (need full re-skin later). This round is the substrate so neither happens.
+- **Legacy `--color-bg` placeholder palette** in `app/globals.css` is OKLCH-neutral, not the Monday `#0073ea` / `#292f4c` / label palette specified in [`design-system.md`](../design-system.md).
+- **Geist font** loaded by shadcn init in `app/layout.tsx` is the wrong family. Donezo uses **Figtree** (body) + **Poppins** (display per `_base.scss` h1–h6).
+- **No `<MenuList />` primitive** exists. Every dropdown in epics 05/06/07/09/11 will need it; building it once now de-risks all of them.
+- **No `lib/icons.ts`** module. Without one, executors will reach for legacy `react-icons` packages or import `lucide-react` ad-hoc, fragmenting the icon set.
+
+## Issues acknowledged but not fixed in this round
+
+- **Dark mode tokens.** Per [00-overview.md](../00-overview.md) and [14-mobile-a11y-polish.md](../14-mobile-a11y-polish.md), dark mode is owned by epic 14. `.dark` block in `app/globals.css` stays untouched (do not edit, do not delete). Dark-derivation rules already specced in [design-system.md §1.1.7](../design-system.md#117-overlay--misc).
+- **shadcn token unification.** Per epic-01-followup-1 decision #1, the two `@theme` blocks coexist for now. Reconciliation is epic 14's problem. This round only **updates values**, not structure.
+- **Custom date/time picker chrome.** Defer to [07](../07-column-system.md).
+- **Status fold pixel-precise port.** Open question in [component-system.md §10](../component-system.md#10-open-questions); doesn't block this round.
+
+## Slices
+
+Two slices, disjoint file scope, run in parallel.
+
+---
+
+## Slice I — `globals.css` + fonts + body chrome
+
+**Owner:** epic-executor (sonnet) · **Branch:** `epic/01-followup-design-system/slice-i` (off `epic/01-followup-design-system`; merges back via PR)
+
+### Scope (files this slice may touch)
+
+- `/app/globals.css` — replace **values** in the spec `@theme` block; replace **values** in shadcn's `:root` block; add new tokens (label colors, group colors, motion, z-index, shadow, surface variants, cell sizes); add scrollbar styles to `@layer base`; update body's `bg-*` / `text-*` if needed.
+- `/app/layout.tsx` — replace `Geist` font import with `Figtree` (body) + `Poppins` (display) from `next/font/google`. Apply `--font-display` to `h1`–`h6` via `globals.css` (not in JSX).
+- `/app/page.tsx` — only if existing `bg-bg` / `text-fg` references break after token rename. **Should not be needed** (we're keeping `--color-bg` and `--color-fg` as synonyms). If touched, change must be cosmetic only — no logic changes.
+
+### Forbidden scope
+
+- `/components/ui/button.tsx` — **do not touch.** Once shadcn `--primary` value is updated to Monday blue, the button auto-restyles. Verify with `pnpm dev` and a manual page reload — DO NOT edit JSX or class strings.
+- `/components/ui/sonner.tsx` — do not touch. Sonner's theme wiring is fine; `useTheme()` still returns the placeholder, which is correct per epic-01-followup-1 decision.
+- `/components/ui/menu-list.tsx` — owned by Slice J.
+- `/lib/icons.ts` — owned by Slice J.
+- The **`.dark` block** in `app/globals.css` — do not edit, do not delete. Owned by epic 14.
+- The **`@theme inline` block** (shadcn-generated) in `app/globals.css` — do not delete or restructure. You **may** edit values inside `:root` that the inline block points at (`--primary`, `--background`, `--border`, etc.). The inline block itself stays as-is.
+- Everything else: `package.json`, `pnpm-lock.yaml`, `tsconfig.json`, `biome.json`, `next.config.ts`, `lib/env.ts`, `lib/utils.ts`, `lib/logger.ts`, `lib/supabase/`, `lib/auth/`, `lib/authorization/`, `lib/actions/`, `lib/validations/`, `lib/cells/`, `lib/realtime/`, `app/(app)/`, `app/(auth)/`, `app/api/`, `app/error.tsx`, `app/not-found.tsx`, `supabase/`, `tests/`, `docs/`, `.github/`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `.env.example`, legacy `frontend/` and `backend/`.
+
+If you discover a need to edit any file outside the scope list, **stop and return a needs-direction report** per `.claude/agents/epic-executor.md`. Do not unilaterally expand scope.
+
+### Dependencies on other slices
+
+None. Independent of Slice J; runs in parallel.
+
+### Spec
+
+#### 1. Replace values in spec `@theme` block
+
+The spec block currently holds OKLCH placeholders. Replace it **in place** with the canonical block from [design-system.md §1.2](../design-system.md#12-appglobalscss-block-canonical), with one modification: keep `--color-bg` and `--color-primary-fg` as **legacy aliases** so existing `app/page.tsx` (`bg-bg`, `text-fg/70`) doesn't break. Mark them deprecated in a comment.
+
+The `@theme` block (lines 9–27 of current `globals.css`) becomes:
+
+```css
+@theme {
+  /* App surface */
+  --color-surface: #ffffff;
+  --color-surface-auth: #f7f7f7;
+  --color-surface-rail: #F6F7FB;
+  --color-surface-nav: #292f4c;
+  --color-surface-info: #f5f6f8;
+  --color-surface-row-hover: #f4f5f8;
+  --color-surface-hover: #dcdfec;
+  --color-surface-active: #cce5ff;
+  --color-primary-selected: #cce5ff;
+  --color-primary-selected-hover: #aed4fc;
+  --color-card-selected: #d9f0ff;
+  --color-chip-member: #e5f4ff;
+
+  /* Primary (Monday blue) */
+  --color-primary: #0073ea;
+  --color-primary-hover: #0060b9;
+  --color-primary-foreground: #ffffff;
+  --color-link: #1f76c2;
+  --color-nav-icon: #6c6cff;
+
+  /* Text & border */
+  --color-fg: #323338;
+  --color-fg-muted: #676879;
+  --color-fg-subtle: #c5c7d0;
+  --color-fg-strong: #1f1f21;
+  --color-border: #d0d4e466;
+  --color-border-solid: #d0d4e4;
+  --color-border-strong: #a8aebb;   /* baked darken($border-color, 20%) */
+  --color-border-rail: #8c93a3;     /* baked darken($border-color, 30%) */
+  --color-shadow-card: #c3c6d4;
+
+  /* Status / priority labels (Monday palette) */
+  --color-label-green: #00c875;
+  --color-label-green-hover: #0f9b63;
+  --color-label-green-selected: #80e3ba;
+  --color-label-yellow: #ffcb00;
+  --color-label-yellow-hover: #c29e11;
+  --color-label-yellow-selected: #ffe580;
+  --color-label-blue: #579bfc;
+  --color-label-blue-hover: #4c7cc1;
+  --color-label-blue-selected: #abcdfd;
+  --color-label-gray: #c4c4c4;
+  --color-label-gray-hover: #98999a;
+  --color-label-gray-selected: #e1e1e1;
+  --color-label-orange: #FDAB3D;
+  --color-label-red: #E2445C;
+  --color-label-purple: #A25DDC;
+  --color-label-pending: #579BFC;
+  --color-label-critical: #333333;
+
+  /* Group accents (12) */
+  --color-group-1: #a25ddc;
+  --color-group-2: #FBBC04;
+  --color-group-3: #F1E4DE;
+  --color-group-4: #FDCFE8;
+  --color-group-5: #F28B82;
+  --color-group-6: #FFF475;
+  --color-group-7: #CCFF90;
+  --color-group-8: #CBF0F8;
+  --color-group-9: #A7FFEB;
+  --color-group-10: #D7AEFB;
+  --color-group-11: #E6C9A8;
+  --color-group-12: #E8EAED;
+
+  /* Overlay */
+  --color-overlay: rgba(41, 47, 76, 0.7);
+
+  /* Layout sizes */
+  --size-cell-h: 36px;
+  --size-cell-w: 140px;
+  --size-cell-w-task: 336px;
+  --size-cell-w-checkbox: 32px;
+  --size-cell-w-conversation: 65px;
+  --size-rail-main: 66px;
+  --size-rail-workspace: 230px;
+
+  /* Radii */
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 10px;
+  --radius-pill: 9999px;
+
+  /* Shadows */
+  --shadow-modal: -3px 4px 14px rgb(0 0 0 / 20%);
+  --shadow-drawer: -6px 0px 14px rgb(0 0 0 / 20%);
+  --shadow-card: 0px 4px 8px rgb(0 0 0 / 20%);
+  --shadow-bulk-bar: 0px 15px 50px rgba(0, 0, 0, 0.3);
+
+  /* Z-index layers */
+  --z-base: 0;
+  --z-sticky: 2;
+  --z-rail: 10;
+  --z-board-header: 30;
+  --z-overlay: 50;
+  --z-modal: 51;
+  --z-drawer: 100;
+  --z-popover: 1000;
+
+  /* Motion durations */
+  --motion-instant: 100ms;
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --motion-medium: 300ms;
+  --motion-slow: 400ms;
+  --motion-drawer: 600ms;
+
+  /* Easing */
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-emphasized: cubic-bezier(0.2, 0, 0, 1);
+  --ease-out: cubic-bezier(0, 0, 0.2, 1);
+
+  /* Fonts (set by next/font/google in app/layout.tsx) */
+  --font-sans: var(--font-figtree), "Roboto", "Rubik", system-ui, sans-serif;
+  --font-display: var(--font-poppins), "Roboto", "Rubik", system-ui, sans-serif;
+
+  /* Legacy aliases (deprecated; kept until epic 14 reconciliation). */
+  --color-bg: var(--color-surface);
+  --color-bg-subtle: var(--color-surface-rail);
+  --color-primary-fg: var(--color-primary-foreground);
+}
+```
+
+Notes on the block:
+- `--color-bg` and `--color-bg-subtle` and `--color-primary-fg` are kept as `var()` aliases so `app/page.tsx`'s `bg-bg` / `text-fg/70` keep working. New code MUST use `--color-surface` / `--color-fg`.
+- `--color-fg` and `--color-border` were already in the spec block under those names; values are now Monday-derived.
+- `--font-sans` and `--font-display` reference `--font-figtree` and `--font-poppins`, which Slice I task #4 below will set via `next/font/google`.
+- `--color-danger`, `--color-success`, `--color-warning` from the old spec block are removed — they were generic placeholders. New code uses the label palette directly (`--color-label-red` for danger, `--color-label-green` for success, `--color-label-yellow` for warning).
+
+#### 2. Replace values in shadcn's `:root` block
+
+The shadcn `:root` block (lines 80–113) drives every shadcn component (Button, Toaster, future Dialog/Popover/etc.). We MUST keep the variable names; we update the values to Monday-derived equivalents.
+
+Replace lines 80–113 with:
+
+```css
+:root {
+  /* Surfaces */
+  --background: #ffffff;                           /* was: oklch(1 0 0) */
+  --foreground: #323338;                           /* was: oklch(0.145 0 0) */
+  --card: #ffffff;                                 /* was: oklch(1 0 0) */
+  --card-foreground: #323338;
+  --popover: #ffffff;
+  --popover-foreground: #323338;
+
+  /* Primary (Monday blue) */
+  --primary: #0073ea;                              /* was: oklch(0.205 0 0) — neutral gray */
+  --primary-foreground: #ffffff;
+
+  /* Secondary / muted / accent — surface variants */
+  --secondary: #F6F7FB;                            /* surface-rail */
+  --secondary-foreground: #323338;
+  --muted: #dcdfec;                                /* surface-hover */
+  --muted-foreground: #676879;                     /* fg-muted */
+  --accent: #cce5ff;                               /* surface-active */
+  --accent-foreground: #323338;
+
+  /* Status */
+  --destructive: #E2445C;                          /* label-red */
+
+  /* Inputs / borders / focus ring */
+  --border: #d0d4e466;
+  --input: #d0d4e466;
+  --ring: #0073ea;                                 /* focus ring = primary */
+
+  /* Charts (placeholders; epic 12 dashboard owns the real palette). Use label palette. */
+  --chart-1: #00c875;
+  --chart-2: #ffcb00;
+  --chart-3: #579bfc;
+  --chart-4: #FDAB3D;
+  --chart-5: #A25DDC;
+
+  /* Radius */
+  --radius: 0.25rem;                               /* was: 0.625rem — Monday cells use 4px corners */
+
+  /* Sidebar (shadcn's sidebar component tokens) */
+  --sidebar: #292f4c;                              /* surface-nav */
+  --sidebar-foreground: #ffffff;
+  --sidebar-primary: #0073ea;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #F6F7FB;                       /* surface-rail */
+  --sidebar-accent-foreground: #323338;
+  --sidebar-border: #d0d4e466;
+  --sidebar-ring: #0073ea;
+}
+```
+
+The `@theme inline` block (lines 37–78) maps these to Tailwind utility names — **do not touch** that block. It's shadcn-generated; the values it points at are what we just updated.
+
+The `.dark` block (lines 115–147) — **do not touch**. Owned by epic 14.
+
+#### 3. Add scrollbar styles to `@layer base`
+
+Append to the existing `@layer base` block at the end of `globals.css`:
+
+```css
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+    scrollbar-width: thin;
+    scrollbar-color: #878787 #D9D9D9;
+  }
+  *::-webkit-scrollbar {
+    width: 8px;
+  }
+  *::-webkit-scrollbar-track {
+    background: #D9D9D9;
+  }
+  *::-webkit-scrollbar-thumb {
+    border-radius: 25px;
+    background-color: #A6A5A5;
+  }
+  body {
+    @apply bg-background text-foreground;
+    font-size: 18px;
+    line-height: 1.6;
+  }
+  html {
+    @apply font-sans;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-display);
+    margin: 0;
+    padding: 0;
+  }
+}
+```
+
+This merges into the existing block — don't create a second `@layer base`. The `* { @apply border-border outline-ring/50; }` line is preserved (shadcn ships it).
+
+The body font-size 18px + line-height 1.6 matches `_base.scss:50-54`. Heading `font-family: var(--font-display)` matches `_base.scss:46`.
+
+#### 4. Swap Geist for Figtree + Poppins in `app/layout.tsx`
+
+Current state (`app/layout.tsx`):
+
+```ts
+import { Geist } from "next/font/google";
+const geist = Geist({ subsets: ["latin"], variable: "--font-sans" });
+// ...
+<html ... className={cn("font-sans", geist.variable)}>
+```
+
+Replace with:
+
+```ts
+import { Figtree, Poppins } from "next/font/google";
+
+const figtree = Figtree({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-figtree",
+  display: "swap",
+});
+
+const poppins = Poppins({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-poppins",
+  display: "swap",
+});
+```
+
+Update the `<html>` element:
+
+```tsx
+<html lang="en" suppressHydrationWarning className={cn("font-sans", figtree.variable, poppins.variable)}>
+```
+
+The body's `bg-bg text-fg antialiased` classes stay — those resolve through the legacy aliases we kept in step 1.
+
+#### 5. Verify
+
+After steps 1–4:
+
+1. `pnpm typecheck` — green.
+2. `pnpm lint` — green.
+3. `pnpm build` — green.
+4. `pnpm dev`, open `localhost:3000`:
+   - Body background is white (`#ffffff`), not pinkish.
+   - "Donezo" h1 renders in Poppins (display).
+   - Body copy renders in Figtree (sans).
+   - The "Ping" button (which is a `<Button>` from `components/ui/button.tsx`) renders with **Monday blue** (`#0073ea`) background — confirming shadcn `--primary` rewire worked.
+   - The "Sign in" link renders with the new `--color-link` (`#1f76c2`).
+   - Scrollbar (when present) is the thin gray Monday style.
+
+If the button doesn't go Monday-blue, **stop and escalate** — that's the canary that the shadcn block rewire failed.
+
+### Definition of done
+
+- `app/globals.css` spec `@theme` block contains all canonical tokens from [design-system.md §1.2](../design-system.md#12-appglobalscss-block-canonical), with `--color-bg` / `--color-bg-subtle` / `--color-primary-fg` retained as legacy `var()` aliases.
+- `app/globals.css` `:root` block contains Monday-derived values for shadcn variables (`--primary: #0073ea`, `--background: #ffffff`, `--foreground: #323338`, etc.).
+- `app/globals.css` `.dark` block is unchanged. `@theme inline` block is unchanged in structure.
+- `app/globals.css` `@layer base` includes scrollbar styles, body font-size 18px / line-height 1.6, and `h1`–`h6` `font-family: var(--font-display)`.
+- `app/layout.tsx` loads Figtree + Poppins via `next/font/google`, no Geist import remaining.
+- `pnpm typecheck`, `pnpm lint`, `pnpm build` all green.
+- Manual smoke test: dev server renders Monday blue Ping button, white surface, Figtree body, Poppins headings.
+
+### Escalation triggers
+
+- Ping button doesn't render Monday-blue after restart — shadcn variable rewire failed; investigate before pressing on.
+- Existing usages outside the scope list break (e.g., `bg-bg` no longer resolves) — the alias setup needs revisiting; escalate.
+- `next/font/google` request fails for Figtree or Poppins (network / Google Fonts unavailable) — escalate; do not silently fall back to a different font.
+- Scrollbar styles break on macOS native (the `scrollbar-width: thin` declaration may collide with shadcn defaults) — escalate.
+
+### Commits
+
+Logical commits, e.g.:
+- `tokens: replace placeholder palette with Monday-derived tokens in globals.css`
+- `tokens: rewire shadcn :root values to Monday palette`
+- `chore(layout): swap Geist for Figtree + Poppins`
+- `style(base): add scrollbar + body typography to @layer base`
+
+No amend, no force-push.
+
+---
+
+## Slice J — `lib/icons.ts` + `<MenuList />` primitive
+
+**Owner:** epic-executor (sonnet) · **Branch:** `epic/01-followup-design-system/slice-j` (off `epic/01-followup-design-system`; merges back via PR)
+
+### Scope (files this slice may touch)
+
+- `/lib/icons.ts` — **new file.** Re-exports the Lucide icons named in [design-system.md §9.2](../design-system.md#92-mapping-table) under their canonical names. Code outside `lib/icons.ts` imports from this module.
+- `/components/ui/menu-list.tsx` — **new file.** Implements the `@mixin menu-modal()` recipe from [_mixins.scss:107-132](../../../frontend/src/assets/styles/setup/_mixins.scss) per [component-system.md §3.2](../component-system.md#32-menumodal-recipe-mixin).
+
+### Forbidden scope
+
+- `/app/globals.css` — Slice I owns it. If you discover that `<MenuList />` needs a token that doesn't exist yet, **stop and escalate** so we can add it to Slice I's token list.
+- `/app/layout.tsx` — Slice I owns it.
+- `/components/ui/button.tsx` — do not touch.
+- `/components/ui/sonner.tsx` — do not touch.
+- `/biome.json` — do not add icon-discipline rules. Per decision #5, icon discipline is a code-review concern, not automation.
+- Everything else in Slice I's forbidden-scope list, plus all of `lib/` outside the new file you create.
+
+### Dependencies on other slices
+
+None. Runs in parallel with Slice I. (Both can be dispatched simultaneously.)
+
+### Spec
+
+#### 1. Create `lib/icons.ts`
+
+This module is the only place in the codebase allowed to import from `lucide-react`. It re-exports a curated set under canonical names that map back to legacy `react-icons` per the design-system mapping table.
+
+```ts
+/**
+ * Canonical icon module.
+ *
+ * The ONLY file allowed to import from `lucide-react`. All other code imports
+ * from `@/lib/icons`. Mapping back to legacy react-icons is documented in
+ * `docs/conversion-plan/design-system.md` §9.2.
+ */
+export {
+  // Workspace / brand
+  Zap as IconLightning,
+  Home as IconHome,
+  Star as IconStar,
+  Pin as IconPin,
+  // Status / interaction
+  Check as IconCheck,
+  Square as IconSquare,
+  Circle as IconCircle,
+  CirclePlus as IconCirclePlus,
+  CircleArrowDown as IconArrowDown,
+  CircleArrowRight as IconArrowRight,
+  // Menus / overflow
+  MoreHorizontal as IconMore,
+  MessageSquarePlus as IconCommentAdd,
+  MessageCircle as IconComment,
+  Maximize2 as IconExpand,
+  // Common actions
+  Plus as IconPlus,
+  X as IconClose,
+  XCircle as IconCloseCircle,
+  Search as IconSearch,
+  Trash2 as IconDelete,
+  FilePlus as IconFileAdd,
+  Bold as IconBold,
+  Menu as IconMenu,
+  LogIn as IconLogIn,
+  // View kinds
+  BarChart3 as IconViewDashboard,
+  Columns3 as IconViewKanban,
+  User as IconViewPerson,
+} from "lucide-react";
+```
+
+Notes:
+- Names use `Icon` prefix (e.g., `IconStar`) for greppability and to make a "canonical icon" easy to spot in JSX.
+- Default Lucide size is `24px`; consumers pass `size={N}` per the design-system §9.2 guidance (`size={20}` for inline cell glyphs, `size={16}` for badges/counts).
+- This list covers the icons enumerated in [design-system.md §9.2](../design-system.md#92-mapping-table). New icons get added to this file as later epics need them.
+
+#### 2. Create `components/ui/menu-list.tsx`
+
+The `<MenuList />` primitive implements the legacy `@mixin menu-modal()` chrome — used by ~10 different dropdowns across the app (group menu, task menu, board menu, login-logout, add-column, add-group, chart-type, etc.).
+
+Per [component-system.md §3.2](../component-system.md#32-menumodal-recipe-mixin), the recipe is:
+
+```ts
+import type { ComponentPropsWithoutRef } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Menu list primitive — the canonical chrome for dropdown menus across the app.
+ *
+ * Implements the legacy @mixin menu-modal() recipe from
+ * frontend/src/assets/styles/setup/_mixins.scss:107-132.
+ *
+ * Usage:
+ *   <MenuList>
+ *     <MenuListItem onClick={...}>Rename</MenuListItem>
+ *     <MenuListItem onClick={...}>Delete</MenuListItem>
+ *   </MenuList>
+ *
+ * Wrap in a <Popover> or <Dialog> for positioning.
+ */
+export function MenuList({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-0 rounded-md border bg-surface p-2 text-sm text-fg shadow-[var(--shadow-modal)]",
+        "border-[color:var(--color-border-strong)]",
+        "z-[var(--z-popover)]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function MenuListItem({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"button">) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-1 text-left",
+        "hover:bg-surface-hover",
+        "focus-visible:bg-surface-hover focus-visible:outline-none",
+        "disabled:opacity-50 disabled:cursor-not-allowed",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+```
+
+Token references must use the new tokens added by Slice I:
+- `bg-surface` → `--color-surface`
+- `text-fg` → `--color-fg` (works via legacy alias OR direct)
+- `bg-surface-hover` → `--color-surface-hover`
+- `border-[color:var(--color-border-strong)]` → `--color-border-strong`
+- `shadow-[var(--shadow-modal)]` → `--shadow-modal`
+- `z-[var(--z-popover)]` → `--z-popover`
+
+If any of these utilities don't resolve at build time, that's a sign Slice I hasn't merged yet — **stop and escalate** rather than substituting a different value. Slice I and Slice J merge into the parent epic branch in either order; neither can ship without the other being correct.
+
+#### 3. Verify
+
+1. `pnpm typecheck` — green.
+2. `pnpm lint` — green.
+3. `pnpm build` — green. (You don't need a JSX usage of `<MenuList />` to verify — the file just needs to compile.)
+4. Optional: import `<MenuList>` in `app/page.tsx` temporarily to eyeball it in `pnpm dev`. Revert the temporary import before committing.
+
+### Definition of done
+
+- `lib/icons.ts` exists with the named re-exports listed above.
+- `components/ui/menu-list.tsx` exists with `<MenuList>` and `<MenuListItem>` exported.
+- Both files compile clean. `pnpm typecheck` + `pnpm lint` + `pnpm build` green.
+- No imports from `lucide-react` outside `lib/icons.ts` (verified by `grep -r "from \"lucide-react\"" --include="*.ts*" .` returning only the `lib/icons.ts` line).
+
+### Escalation triggers
+
+- Token utility (`bg-surface`, `bg-surface-hover`, etc.) doesn't resolve — Slice I likely incomplete or merged with bug; coordinate before continuing.
+- A Lucide icon listed above doesn't exist in the installed `lucide-react` version (e.g., a rename happened upstream) — escalate; do not silently substitute.
+- Existing `lucide-react` imports outside `lib/icons.ts` (currently in `components/ui/sonner.tsx`) — these are pre-existing and out of scope. Do **not** edit `sonner.tsx` to route through `lib/icons.ts`. Migration of the 5 existing icon imports there is deferred to epic 14 along with theme reconciliation; flag it in your handoff report so the followup-3 reviewer knows.
+
+### Commits
+
+Logical commits, e.g.:
+- `lib(icons): add canonical lucide-react re-export module`
+- `ui(menu-list): add MenuList primitive matching legacy @mixin menu-modal`
+
+No amend, no force-push.
+
+---
+
+## After both slices land — review pass
+
+1. Both slices PR into `epic/01-followup-design-system`. PR-into-main from the followup branch only after both are reviewed.
+2. `epic-researcher` (Opus) runs the foundation review pass against the merged followup branch. Definition-of-done check:
+   - All locked tokens from [design-system.md](../design-system.md) are in `app/globals.css`.
+   - Figtree + Poppins load via `next/font/google`.
+   - shadcn `<Button>` renders Monday blue without JSX changes.
+   - `<MenuList />` primitive exists and compiles.
+   - `lib/icons.ts` is the only `lucide-react` consumer (modulo the pre-existing `sonner.tsx`).
+   - Scrollbar matches the legacy thin-gray style.
+3. If the review pass surfaces gaps, write `epic-01-followup-3.md` and dispatch.
+4. If clean: open the PR from `epic/01-followup-design-system` → `main`. Merge unblocks epic 04 re-planning.
+
+## Cross-references
+
+- Tokens: [`design-system.md`](../design-system.md)
+- Component contracts: [`component-system.md`](../component-system.md)
+- Original epic spec: [`01-foundation.md`](../01-foundation.md)
+- Prior followup: [`_dispatch/epic-01-followup-1.md`](epic-01-followup-1.md)
+- Executor rules: [`.claude/agents/epic-executor.md`](../../../.claude/agents/epic-executor.md)

--- a/docs/conversion-plan/component-system.md
+++ b/docs/conversion-plan/component-system.md
@@ -1,0 +1,468 @@
+# Donezo Component System (Locked)
+
+The companion to [`design-system.md`](design-system.md). This doc inventories every legacy component that has product meaning and locks down its visual + interaction contract for the new app.
+
+**Translation rule:** legacy components are CRA + SCSS + MUI. New components are RSC where possible, `"use client"` where interaction is required, styled via shadcn/ui (Base UI primitives) + Tailwind tokens. We rebuild from these specs, not from JSX.
+
+**Marketing/landing components are not ported.** The legacy `cmps/home/`, `cmps/custom/`, and `home-header.jsx` are out of scope. The new app's only public route is the Google sign-in screen ([03](03-auth.md)).
+
+**File path conventions in this doc:**
+- Legacy JSX: `frontend/src/cmps/<area>/<file>.jsx`
+- Legacy SCSS: `frontend/src/assets/styles/cmps/<…>/<file>.scss`
+- New components land under `components/<area>/<Name>.tsx` per the layout in [00-overview.md](00-overview.md)
+
+Each entry below has the same shape:
+- **What** — purpose
+- **Where** — appears on which routes
+- **Visual contract** — states, key dimensions, exact tokens
+- **Interaction contract** — hover, focus, transitions, drag, optimistic UI
+- **Lands in** — the epic that ships it
+- **Fidelity bar** — `must-match` (every detail), `match` (visual + interaction match, deviations allowed if reasoned), or `inspired` (free to redesign within the system)
+
+---
+
+## 0. The Monday-feel must-haves
+
+These five components carry most of the product's visual identity. If any of them ship as generic shadcn defaults, the app will look wrong even if every other pixel is right. Tag them `must-match` and review screenshots before merge:
+
+1. **Status / priority pill** with the diagonal "fold" reveal on hover
+2. **Group header** with the colored 6px left stripe and sticky behavior
+3. **Task row** with the inline blockquote title, hover-revealed menu, and "on-typing" wash
+4. **Workspace sidebar** with the slide-out collapse and pill-shaped toggle handle
+5. **Get-started CTA** (gradient pill button with the shifting arrow)
+
+---
+
+## 1. Layout shells
+
+### 1.1 `MainSidebar` (icon column)
+
+- **What:** the leftmost vertical rail containing brand glyph, tool icons, user avatar, and login menu.
+- **Where:** `app/(app)/layout.tsx` — every authed route.
+- **Legacy:** `frontend/src/cmps/sidebar/main-sidebar.jsx`, [_main-sidebar.scss](../../frontend/src/assets/styles/cmps/sidebar/_main-sidebar.scss).
+- **Visual contract:**
+  - Background `--color-surface-nav` (`#292f4c`), full-height, `position: sticky; top: 0`.
+  - Min width `66px` desktop. On mobile (`max-md`) collapses to a 8vh bottom bar (`position: fixed; bottom: 0; flex-direction: row`).
+  - Internal sections: brand link top, tools middle (with `border-top` + `border-bottom` in `--color-border` 40%), bottom for menu icon + avatar.
+  - Tool icon container `56 × 36px`, centered.
+  - Avatar `37.4 × 37.4px`, white `1.6px` border, `border-radius: 50%`.
+  - Icon glyphs white at `rem(23px)` (`~23px`) base; menu icon at `42 × 42px` in `--color-nav-icon` (`#6c6cff`).
+- **Interaction contract:**
+  - Tool/menu hover applies `bg-color: rgba(0,0,0,.6)` + `border-radius: 10px`. Use `--color-nav-hover` (token to add: `rgba(0,0,0,.6)` baked into `--color-surface-nav-hover`).
+  - Avatar hover: `transform: scale(.9)` over `--motion-base`.
+  - Brand link hover: same pattern as tool hover.
+  - Mobile: `bottom: 0`, gap `30px`, the open-workspace icon appears (white, 24px).
+- **Lands in:** [05](05-workspaces-boards.md).
+- **Fidelity bar:** `must-match` — this rail is half of the "Monday look at a glance."
+
+### 1.2 `WorkspaceSidebar` (slide-out workspace panel)
+
+- **What:** secondary rail listing workspace name, workspace tools (Search, Add board, Templates, ...), favorites, and the board list.
+- **Where:** `app/(app)/layout.tsx`, slides in/out next to `MainSidebar`.
+- **Legacy:** `workspace-sidebar.jsx` + [_workspace-sidebar.scss](../../frontend/src/assets/styles/cmps/sidebar/_workspace-sidebar.scss).
+- **Visual contract:**
+  - Open: width `230px`. Closed: width `0` (mobile) / `30px` (narrow+).
+  - Background `--color-surface-rail` (`#F6F7FB`); right border `1px solid --color-border-rail` (baked `darken($border-color, 30%)`).
+  - Header section with workspace logo (`30×30` rounded-`8px` tile in `--color-label-green` with white "lightning" glyph, plus a `home` overlay icon) and bold workspace title at 16px weight 700 in `--color-fg`.
+  - Workspace items list: `font-size: 14px`, padding `4px`, gap `6px`. Hover bg `--color-surface-hover`, radius `4px`.
+  - Search-board input: `border-radius: 4px`, `height: 31px`. On focus-within: `0.5px` border `--color-primary`, bg white.
+  - Favorites empty-state: 80px star icon, centered text in `--color-fg`, line-height `1.5`.
+  - "Toggle workspace" pill: absolute, right edge of rail, `top: 13px`. White circle, `1px` border `#c3c6d4`, padding `4px`, radius `20px`. On hover: bg `--color-primary`, color white, padding asymmetric (right shrinks, left grows by `12px`) over `--motion-base`.
+- **Interaction contract:**
+  - Open/close: width animates over `--motion-slow` (`.4s`); inner header opacity `0 → 1` with `transition-delay: 0.25s` so the chrome appears *after* the rail finishes opening (don't fade them in parallel — the staggered reveal is the look).
+  - Active board row: bg `--color-surface-active`, radius `4px`.
+  - Mobile open state takes 100vw; toggle pill hidden.
+- **Lands in:** [05](05-workspaces-boards.md).
+- **Fidelity bar:** `must-match`.
+
+### 1.3 `BoardHeader` (top of board)
+
+- **What:** board title bar with title (inline edit), star, board tools (activity, members, invite), description link, and view tabs.
+- **Where:** `app/(app)/w/[slug]/b/[boardId]/layout.tsx`.
+- **Legacy:** `board/board-header.jsx` + [_board-header.scss](../../frontend/src/assets/styles/cmps/board/_board-header.scss).
+- **Visual contract:**
+  - Padding: `16px 30px 0 38px` desktop; `16px 10px 0 10px` mobile.
+  - `position: sticky; top: 0; left: 0; z: --z-board-header`. Bg white.
+  - Title H1: 24px (narrow+) / 15px (mobile), letter-spacing `0.5px`, color `--color-fg`. Hover shows `1px solid --color-border-strong` border (turns the title into a pre-edit affordance).
+  - Star: `--color-label-yellow` when filled.
+  - Board tools row: gap 16px, each item `padding: 4px`, radius `6px`, hover bg `--color-surface-hover`.
+  - Members avatar pile (`<MemberStack />`): white border, 24px diameter, `-5px` overlap; "+N" overflow tile in white with `1px solid --color-border` and `--color-fg` text.
+  - View tabs row: each tab `height: 32px`, padding `0 8px`, `font-size: 14px`, font-weight 500. Active state: bottom border `2px solid --color-primary` (NO animation — snap on).
+  - Border line between tabs and content: `1px solid --color-border-strong`.
+- **Interaction contract:**
+  - Title becomes contenteditable on click; outline `1px solid --color-primary` on focus-visible. (See [Inline editable title](#21-inline-editable-title-blockquote-pattern) below.)
+  - Description-link span: color `--color-link`; hover underlines.
+  - Tabs hover bg `--color-surface-hover`, radius top-only `4px 4px 0 0`.
+- **Lands in:** [05](05-workspaces-boards.md) (skeleton with only Table tab enabled), [12](12-alternate-views.md) (other tabs).
+- **Fidelity bar:** `must-match`.
+
+### 1.4 `BoardFilter` toolbar
+
+- **What:** the "+ New Item" split-button, search expander, person filter, and sort/hide/group controls below the board header.
+- **Where:** above `<BoardTable />`.
+- **Legacy:** `board/board-filter.jsx` + [_board-filter.scss](../../frontend/src/assets/styles/cmps/board/_board-filter.scss).
+- **Visual contract:**
+  - Row gap `5px`; each tool `height: 32px`, `font-size: 14px`.
+  - Tools (`Person/Filter/Sort/Hide/Group/Search`): padding `0 8px`, color `--color-fg-muted`, glyph `18px`. Hover bg `--color-surface-hover`, radius `4px`.
+  - **Primary "New Item" split-button** (the visual anchor of the toolbar):
+    - Outer container bg `--color-primary`, radius `5px`, `height: 32px`, white text.
+    - Left half (`.new-task-btn`): padding `4px 8px`. Hover bg `--color-primary-hover`, only the left two corners round (5px). Transition `--motion-slow`.
+    - Right half (`.drop-down-btn`): `1px` left border `--color-primary-hover`, padding `0 8px`, chevron `15px`. Hover bg `--color-primary-hover`, only right two corners round.
+  - Search input: collapsed width `58px`. On focus-within: chrome border `0.5px --color-primary`, bg white. On focus: input width animates `58 → 140px` over `--motion-medium`.
+  - Person-filter chip when active: bg `--color-primary-selected`, radius `4px`.
+- **Interaction contract:**
+  - Search transitions cursor `pointer → text` on focus.
+  - Filter/sort/hide/group open popovers (`<DynamicModal />` pattern below).
+- **Lands in:** [11](11-filtering-views.md). (A simplified search-only version may ship in [06](06-groups-tasks-table.md) — the split-button itself ships there.)
+- **Fidelity bar:** `must-match` (the split-button), `match` (rest).
+
+### 1.5 ~~Marketing header~~ — REMOVED
+
+Marketing surfaces are out of scope per [00-overview.md](00-overview.md). The only public route is Google sign-in ([03](03-auth.md)). No `<HomeHeader />`, no landing page.
+
+---
+
+## 2. Board work surface
+
+### 2.1 Inline-editable title (blockquote pattern)
+
+- **What:** a `<blockquote contentEditable>` that swaps from display to edit on focus. Used for the board title, group title, task title, and board description.
+- **Visual contract:**
+  - Default: borderless, padded.
+  - Hover: outline `1px solid --color-border-strong`, radius `5px`.
+  - Focus-visible: outline `1px solid --color-primary`, radius `5px`.
+  - Editing state ("on-typing"): row bg `--color-surface-active`.
+- **Interaction contract:**
+  - Click to enter edit mode (no double-click). `Enter` commits + blurs; `Esc` reverts. The whole row enters "on-typing" wash so collaborators see the edit live.
+  - On blur, fire optimistic update — see [Optimistic cell pattern](#26-optimistic-cell-pattern).
+- **Lands in:** [05](05-workspaces-boards.md) (board title), [06](06-groups-tasks-table.md) (group + task), [09](09-comments-activity.md) (board description).
+- **Fidelity bar:** `must-match`.
+
+### 2.2 `GroupHeader`
+
+- **What:** the row that introduces a group of tasks: collapse arrow, colored title, task count, overflow menu.
+- **Where:** every board view that shows groups.
+- **Legacy:** `board/title-group-preview.jsx` and parts of `group-preview.jsx` + [_group-preview.scss](../../frontend/src/assets/styles/cmps/group/_group-preview.scss).
+- **Visual contract:**
+  - `position: sticky; top: 182px` (narrow+) / `149px` (mobile); bg white; height `40px`; line-height `24px`.
+  - Title H4: font-weight 600, font-size `18px`, padding `4px`, color matches the group's accent (`--color-group-N`).
+  - Task count: `font-size: 14px`, color `--color-fg-muted`, opacity `0 → 1` on group hover over `--motion-base`.
+  - Arrow chevron: `16px`, `margin-left: 13px`, cursor pointer.
+  - Group overflow menu (left, off-canvas): `width: 40px`, sits at `left: -38px`. Glyph `BiDotsHorizontalRounded` 20px. Hidden by default; appears on row hover.
+- **Interaction contract:**
+  - Hover on group exposes overflow menu glyph.
+  - Title becomes editable per [§2.1](#21-inline-editable-title-blockquote-pattern).
+  - Active "show border" state: `1px solid --color-primary`, radius `4px`.
+- **Lands in:** [06](06-groups-tasks-table.md).
+- **Fidelity bar:** `must-match`.
+
+### 2.3 `TaskRow` / `TaskPreview`
+
+- **What:** a single row of the board table. Handles drag handle reveal, checkbox, inline title, comment count, expand-to-drawer link, and the dynamic cells.
+- **Where:** every Table view; the row is the core read/write surface.
+- **Legacy:** `task/task-preview.jsx` + [_task-preview.scss](../../frontend/src/assets/styles/cmps/_task-preview.scss).
+- **Visual contract:**
+  - Row height `36px`. Font size `14px`.
+  - Sticky-div (left): bg white, `border-left: 6px solid <group-accent>`, sticky at `left: 40px` (mobile `left: 0`, min-width `240px`).
+  - Drag/menu handle (`task-menu`): off-canvas at `left: -47px`, `width: 41px`, `height: 40px`. Glyph hidden until row hover.
+  - Checkbox cell `33px` wide, `1px solid --color-border-strong`.
+  - Title cell `336px` wide, blockquote per [§2.1](#21-inline-editable-title-blockquote-pattern), with `Open` affordance hidden until hover.
+  - Comment-count badge: `14×13px` circle, bg `--color-primary`, white text, font-size `10px`, top-right of chat icon.
+- **Interaction contract:**
+  - Row hover reveals: drag handle, "Open" expand affordance, comment-add icon (default).
+  - Editing title applies "on-typing" wash to row + sticky-div.
+  - Open affordance navigates to task drawer route.
+- **Lands in:** [06](06-groups-tasks-table.md). Cells beyond title are filled in by [07](07-column-system.md).
+- **Fidelity bar:** `must-match`.
+
+### 2.4 Cell components (per type)
+
+A shared cell skeleton: `min-width: 140px`, `height: 36px`, `1px solid --color-border-strong` border. Each cell type extends.
+
+| Cell | Legacy SCSS | Key visual | Interaction | Lands in |
+|---|---|---|---|---|
+| `StatusCell` / `PriorityCell` | [_status-priority-picker.scss](../../frontend/src/assets/styles/cmps/task-picker/_status-priority-picker.scss) | Full-bleed bg = label color; centered white label text; **diagonal "fold" in top-right reveals on hover** (border-width `0 → 10×10 → 15×15px` over `--motion-base` with `transition-delay: .2s`); empty state shows `--color-label-gray` (`#c4c4c4`) bg with no text | Click opens `<StatusPicker />` popover; popover lists labels (centered, fixed-width 152px chips) + "Edit Labels" button bottom (1px top border `--color-border-strong`) | [07](07-column-system.md) |
+| `PersonCell` | [_member-picker.scss](../../frontend/src/assets/styles/cmps/task-picker/_member-picker.scss) | Stacked avatars (26px circle, `-5px` overlap); empty state shows muted person glyph; bg neutral | Click opens member-picker modal | [07](07-column-system.md) |
+| `DateCell` | [_date-picker.scss](../../frontend/src/assets/styles/cmps/task-picker/_date-picker.scss) | Centered text input; max-width 140px; transparent bg | Hover: `0.2px` border `--color-surface-hover`, text `--color-primary`. Focus: border `--color-primary`. Click opens date popover | [07](07-column-system.md) |
+| `NumberCell` | [_number-picker.scss](../../frontend/src/assets/styles/cmps/task-picker/_number-picker.scss) | Centered number input; on hover reveals `+`/`-` icons in `--color-primary` and a `clear` chip top-right (bg `--color-surface-hover`, radius 3px) | Hover reveals controls; focus shows `--color-primary` border | [07](07-column-system.md) |
+| `CheckboxCell` | [_checkbox-picker.scss](../../frontend/src/assets/styles/cmps/task-picker/_checkbox-picker.scss) | Centered icon; checked color `--color-primary`, unchecked `--color-fg`. Hover wash `rgba(0,0,0,0.05)` over `--motion-base` | Click toggles | [07](07-column-system.md) |
+| `FileCell` | [_file-picker.scss](../../frontend/src/assets/styles/cmps/task-picker/_file-picker.scss) | Hidden file input; centered "+" icon (`19px`, opacity `0 → 1` on hover) | Hover reveals upload affordance; click opens file picker | [10](10-attachments.md) |
+| `UpdatedByCell` | [_update-picker.scss](../../frontend/src/assets/styles/cmps/task-picker/_update-picker.scss) | Avatar (26px) + relative time `(2h, 5d, 3w)` from `calculateTime` util | Read-only | [07](07-column-system.md) |
+| Other types (`text`, `email`, `phone`, `country`, `link`, `tags`, `rating`, `currency`, `vote`, `week`, `location`, `formula`) | — | Inherit cell skeleton; per-type editor follows the picker patterns above. **Match** the visual rhythm (centered content, `--color-primary` focus border, hover wash) | Open editor on click; ESC cancels, blur commits | [07](07-column-system.md) |
+
+**Fidelity bar for all cells:** `must-match`. The status fold and the `--color-primary` focus borders are characteristic.
+
+### 2.5 Group color stripe
+
+- **What:** the 6px solid left bar on every row, color = group's accent.
+- **Where:** every task row, every group header.
+- **Visual contract:** see [§2.3](#23-taskrow--taskpreview) sticky-div.
+- **Interaction contract:** static. Color is editable via the [color-palette popover](#33-colorpalette-popover).
+- **Fidelity bar:** `must-match`.
+
+### 2.6 Optimistic cell pattern
+
+- **Pattern:** on cell change, update Zustand store immediately; fire server action; on success, reconcile via Realtime broadcast; on failure, revert + toast.
+- **Visual signal during in-flight edit:** none beyond the "on-typing" wash for inline-editable titles. Cells flick to their new value instantly.
+- **Lands in:** [06](06-groups-tasks-table.md) for title; [07](07-column-system.md) per cell type.
+- **Fidelity bar:** `must-match`.
+
+---
+
+## 3. Modals & popovers
+
+### 3.1 `DynamicModal` (popover container)
+
+- **What:** the floating popover used for status pickers, priority pickers, group menus, board menus, color palette, etc. Position computed from the click target's rect.
+- **Legacy:** `modal/dynamic-modal.jsx` + [_dynamic-modal.scss](../../frontend/src/assets/styles/cmps/modal/_dynamic-modal.scss).
+- **Visual contract:**
+  - `position: absolute`, bg white, `padding: 8px`, `border-radius: 8px`, `border: 1px solid --color-border-strong`, `box-shadow: --shadow-modal`, `z-index: --z-popover` (1000).
+- **Interaction contract:**
+  - Open positions are computed from the trigger element. Outside-click + Esc close.
+  - Reuse Base UI's `<Popover>` (via shadcn) and apply the legacy chrome.
+- **Fidelity bar:** `must-match` chrome; `match` positioning logic (Base UI's Floating UI integration is fine).
+
+### 3.2 `MenuModal` recipe (mixin)
+
+The `@mixin menu-modal()` ([_mixins.scss:107-132](../../frontend/src/assets/styles/setup/_mixins.scss)) is reused by ~10 different menus (task-tools, group-menu, task-menu, login-logout, board-description-modal items). Lock the recipe:
+
+```css
+.menu-modal {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);    /* 8px */
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 40px;
+  color: var(--color-fg);
+  font-size: 14px;
+  z-index: var(--z-rail);             /* 10 */
+  padding: 8px;
+  box-shadow: var(--shadow-modal);
+  border: 1px solid var(--color-border-strong);
+}
+.menu-modal > * {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+}
+.menu-modal > *:hover:not(.color-palette) {
+  background: var(--color-surface-hover);
+  border-radius: 8px;
+}
+```
+
+All dropdown menus (board, group, task, add-column, add-group, chart-type, login-logout) use this recipe. Build it once as `<MenuList />` and inherit.
+
+- **Lands in:** [01](01-foundation.md) as a base primitive.
+- **Fidelity bar:** `must-match`.
+
+### 3.3 `ColorPalette` popover
+
+- **What:** the 12-swatch grid for picking a group's accent color.
+- **Legacy:** `cmps/color-palette.jsx` + [_color-palette-modal.scss](../../frontend/src/assets/styles/cmps/modal/_color-palette-modal.scss).
+- **Visual contract:**
+  - Container width `142px`, flex-wrap, swatches at margin `5px`.
+  - Swatch: `BsFillCircleFill` (Lucide `Circle` filled), font-size `20px`, fill = palette color (one of the 12 group colors).
+- **Interaction contract:** click swatch → fires `setGroupColor`. No checkmark on the active swatch in legacy (consider adding for a11y).
+- **Lands in:** [06](06-groups-tasks-table.md) (group recolor uses it).
+- **Fidelity bar:** `match` (palette is `must-match`; layout flexibility is fine).
+
+### 3.4 `StatusLabelEditor` popover
+
+- **What:** the popover that opens from a status cell to pick or edit labels.
+- **Legacy:** `modal/modal-status-priority.jsx` + [_status-priority-modal.scss](../../frontend/src/assets/styles/cmps/modal/_status-priority-modal.scss).
+- **Visual contract:**
+  - `<ul>` of label chips, padding `8px`, font-size `14px`, gap `8px`, color white.
+  - Each chip: min-width `152px`, `height: 32px`, centered. Bg = label color.
+  - "Edit Labels" button at the bottom: top border `1px solid --color-border-strong`, button width `152px`, white bg, `--color-fg` text, padding `4px 8px`, glyph 20px. (Triangle indicator visible above the popover).
+- **Interaction contract:** click chip selects; "Edit Labels" navigates to label editor (a sub-popover or modal).
+- **Lands in:** [07](07-column-system.md) (status/priority cell type).
+- **Fidelity bar:** `must-match`.
+
+### 3.5 `TaskDrawer` (right-slide modal)
+
+- **What:** the right-side drawer that opens when a task is expanded. Tabs: Updates / Activity / Files.
+- **Legacy:** `modal/task-modal.jsx` + [_board-modal.scss](../../frontend/src/assets/styles/cmps/modal/_board-modal.scss).
+- **Visual contract:**
+  - `position: fixed; top: 0; right: 0; height: 100vh; min-width: 570px` (mobile: 100vw).
+  - Bg white, `border-inline-start: 1px solid #ccc`.
+  - Header: `padding: 20px 20px 6px 24px`, height `53px`, font-size `18px`. Close glyph color `#777`.
+  - Tab strip: padding `0 24px`, `1px solid --color-border` bottom. Each tab: padding `8px`, font-weight 500, font-size `14px`. Hover bg `--color-surface-hover`, only top corners round (`4px 4px 0 0`). Active: bottom border `2px solid --color-primary`.
+  - Content area `85vh` scroll, scrollbar hidden (`::-webkit-scrollbar { display: none }`).
+  - Update editor card: `outline: 1px solid --color-primary`, `border-radius: 4px`, height `145px`. Toolbar row with style toggles each `4px 8px`, hover bg `--color-surface-hover`. Save button: bg `--color-primary` white, `height: 32px`, `border-radius: 4px`, hover `--color-primary-hover`.
+- **Interaction contract:**
+  - Slide in: `transform: translateX(100% → 0)` over `--motion-drawer` (`.6s`), shadow fades in.
+  - Outside click + Esc close. Route stays at `…/t/[taskId]`.
+- **Lands in:** [09](09-comments-activity.md) (drawer + Updates tab + Activity tab); Files tab in [10](10-attachments.md).
+- **Fidelity bar:** `must-match`.
+
+### 3.6 `BoardDescriptionModal` (centered, two-pane)
+
+- **What:** big info modal showing the board description on the left and meta (created-by, members, lightning workspace tile) on the right.
+- **Legacy:** [_board-description-modal.scss](../../frontend/src/assets/styles/cmps/modal/_board-description-modal.scss).
+- **Visual contract:** `850 × 550px` (`max-w 95vw`, `max-h 90vh`), `border-radius: 8px`, shadow `1px 0 20px black`. Right pane bg `--color-surface-info`. Description blockquote uses inline-editable [§2.1](#21-inline-editable-title-blockquote-pattern) pattern.
+- **Lands in:** [05](05-workspaces-boards.md) or [06](06-groups-tasks-table.md) (whichever ships board description editing).
+- **Fidelity bar:** `match`.
+
+### 3.7 `CreateBoardModal` (centered)
+
+- **Legacy:** [_create-board-modal.scss](../../frontend/src/assets/styles/cmps/modal/_create-board-modal.scss).
+- **Visual contract:** `width 500px`, padding `16px 32px 32px`, `border-radius: 8px`, shadow `--shadow-modal`. H1 `32px / 500`, H3 `14px / 400`. Form input full-width, `border-radius: 4px`, `1px solid --color-border`, height `40px`.
+- **Lands in:** [05](05-workspaces-boards.md).
+- **Fidelity bar:** `match`.
+
+### 3.8 `MemberModal` / `InviteModal`
+
+- **Legacy:** [_member-modal.scss](../../frontend/src/assets/styles/cmps/modal/_member-modal.scss).
+- **Visual contract:** `width 360px` desktop / `250px` mobile. Member chips in `taskMembers`: padding `4px 8px`, bg `--color-chip-member`, radius `8px`, with avatar `22 × 22`. Search row: padding `4px`, width `320px`, radius `8px`, `2px` border `--color-border-strong`.
+- **Lands in:** [05](05-workspaces-boards.md).
+- **Fidelity bar:** `match`.
+
+### 3.9 `BulkActionBar` (floating)
+
+- **What:** the floating bottom-aligned action bar that appears when ≥1 task is selected.
+- **Legacy:** `modal/task-tools-modal.jsx` + [_task-tools-modal.scss](../../frontend/src/assets/styles/cmps/modal/_task-tools-modal.scss).
+- **Visual contract:**
+  - `position: fixed; bottom: 35px; height: 63px; width: 60%`. Inset positions left/right roughly center it.
+  - Bg white, `border-radius: 5px`, `box-shadow: --shadow-bulk-bar`.
+  - Left section: count tile width `63px`, bg `--color-primary`, white text, `font-size: 24px`, top/bottom-left corners rounded.
+  - Middle: task info, padding `0 20px`, `font-size: 20px`, group color shown at `font-size: 10px`.
+  - Right: action buttons (`Duplicate`, `Export`, `Move`, `Delete`...) — column layout, glyph 18px in `--color-fg-muted`, label 12px. Hover glyph color `--color-primary`.
+  - Close button: width `63px`, `2px` left border `--color-shadow-card`. Glyph 26px black.
+  - Slide-in animation: `opacity + transform` over `--motion-fast`.
+- **Lands in:** [06](06-groups-tasks-table.md).
+- **Fidelity bar:** `must-match`.
+
+### 3.10 Add-column / Add-group / Filter-member modals
+
+Inherit the [MenuModal recipe](#32-menumodal-recipe-mixin). Add-column is a flex-wrap grid (240px wide, 120px cells). Filter-member is a 400px panel with circular member avatars (30px) where active members get a `--color-card-selected` ring background. — All `match` fidelity.
+
+---
+
+## 4. Comments & activity
+
+### 4.1 `CommentList` & `CommentItem`
+
+- **Legacy:** `task/comment-preview.jsx` + [_comment-preview.scss](../../frontend/src/assets/styles/cmps/_comment-preview.scss).
+- **Visual contract:**
+  - Item: `border-radius: 4px`, `1px` border `--color-border-strong`, padding `16px`, margin-bottom `16px`.
+  - Header: bottom-padding `8px`, `font-size: 14px`, color `--color-fg-muted`.
+    - Left: avatar (26px), name in `--color-fg`, `font-size: 16px`, gap `8px`.
+    - Right: timestamp + overflow menu glyph (24×24 hover wash to `--color-surface-hover`).
+  - Body `<p>`: padding `0 16px 16px 16px`, max-width `540px`, word-wrap.
+  - Cancel button: white bg, `--color-fg` text, `height: 32px`, `border-radius: 4px`, padding `4px 8px`. Hover bg `--color-surface-hover`.
+- **Interaction:** edit/delete/react/reply per item. Edited shows "edited" tag. Deleted leaves placeholder.
+- **Lands in:** [09](09-comments-activity.md).
+- **Fidelity bar:** `must-match`.
+
+### 4.2 `ActivityList` & `ActivityItem`
+
+- **Legacy:** `activity-preview.jsx` + [_activity-preview.scss](../../frontend/src/assets/styles/cmps/_activity-preview.scss).
+- **Visual contract:**
+  - Row: padding `8px 0`, `1px` bottom border `--color-shadow-card`, margin `0 25px`, gap `5%`, font-size `16px`, height `60px`.
+  - Avatar 30×30. Time-title col `200px` (mobile `100px`, font 12px).
+  - From-to col: 200px, label spans width 90px (mobile 40px, height 30px, font 10px), arrow icon 35px in `--color-label-gray`. Labels use the status-color bg with white text, `border-radius: 4px`.
+- **Lands in:** [09](09-comments-activity.md).
+- **Fidelity bar:** `must-match`.
+
+---
+
+## 5. ~~Marketing components~~ — REMOVED
+
+`<GetStartedButton />`, `<HomeTeaser />`, `<HomeScreenshot />` and the rest of the legacy `cmps/home/` and `cmps/custom/` files are not ported. The corresponding tokens (brand-violet, home gradients, CTA glow shadow) were dropped from [`design-system.md`](design-system.md). Per [00-overview.md](00-overview.md), the only public surface is Google sign-in.
+
+---
+
+## 6. Auth
+
+### 6.1 `LoginSignup` form
+
+- **Legacy:** `pages/login-signup.jsx` + [_login-signup.scss](../../frontend/src/assets/styles/views/_login-signup.scss).
+- **Visual contract:**
+  - Page wash `--color-surface-auth` (`#f7f7f7`). Header bar `height: 65px`, `1px` bottom border `#e0e0e0`.
+  - Form container centered, padding-top 40px. H1 40px / 100 weight in `#333`.
+  - Inputs `width: 328px`, `border-radius: 4px`, `1px solid #ccc`, padding `6px 12px`, font-size 16px, margin-bottom 16px.
+  - Primary button: `width: 328px`, `border-radius: 4px`, font 18px, bg `--color-primary`, white text.
+  - Google button: bordered `1px solid #c5c7d0`, padding `12px 16px`, gap `8px`, radius `4px`, white bg, label `font-size: 14px`.
+  - Split-line: 200px wide separators with `0.5px` border `#c5c7d0`, gap `16px`.
+  - "Sign up" link: color `#0fa2e2`, transparent bg, font-size 16px.
+- **Lands in:** [03](03-auth.md).
+- **Fidelity bar:** `match`. (We're swapping Google-only for Google + email/password + magic link, so the form structure changes; visual chrome stays.)
+
+### 6.2 `Logo`
+
+- **Legacy:** `cmps/logo.jsx` + [_logo.scss](../../frontend/src/assets/styles/cmps/_logo.scss).
+- **Visual contract:** PNG icon 18px (normal+ 20px) + word-mark "donezo" at 20px (normal+ 24px), `font-weight: 700`, color black. Gap `7px`.
+- **Lands in:** [01](01-foundation.md). Convert PNG → SVG at first opportunity.
+- **Fidelity bar:** `must-match`.
+
+---
+
+## 7. Kanban view
+
+### 7.1 `KanbanBoard` lanes & cards
+
+- **Legacy:** `kanban/group-list-kanban.jsx` + [_group-list-kanban.scss](../../frontend/src/assets/styles/cmps/kanban/_group-list-kanban.scss), `_group-preview-kanban.scss`, `_task-list-kanban.scss`, `_task-preview-kanban.scss`.
+- **Visual contract:**
+  - Lane (`group-preview-kanban`): width `260px`, bg `--color-surface-rail`, header `44px` tall, white text on group color, top corners `8px` rounded.
+  - Card (`task-container`): bg white, `border-radius: 4px`, `box-shadow: --shadow-card`, font 13px, margin-bottom 8px. Inner padding 8px, gap 8px.
+  - Card title row: 36px tall, gap 4px, with chat icon right (24px). Comment count badge same as table (`14×13` circle, bg `--color-primary`).
+  - Card content area: stacked picker rows, each 36px tall with bg `--color-surface-info` (`#f5f6f8`).
+  - Lane container max-height `410px`, padding-left `38px`, gap `30px`, flex-wrap.
+- **Interaction:** drag a card between lanes → updates the group-by cell. Drag within lane → updates `task.position`.
+- **Lands in:** [12](12-alternate-views.md).
+- **Fidelity bar:** `match` (the Kanban port is the loosest area; legacy code path is technically not even routed in JSX).
+
+---
+
+## 8. Empty states & loaders
+
+### 8.1 `Loader`
+
+- **Legacy:** `loader.jsx` + [_loader.scss](../../frontend/src/assets/styles/cmps/_loader.scss). Centered `loader.gif`.
+- **Replace with:** `<Skeleton />` (shadcn) for layouts; spinner only for explicit "we don't know how long" cases (file uploads).
+- **Lands in:** [01](01-foundation.md) for primitives; populated in [14](14-mobile-a11y-polish.md).
+- **Fidelity bar:** `inspired`.
+
+### 8.2 `LastViewed`
+
+- **Legacy:** `last-viewed.jsx` + [_last-viewed.scss](../../frontend/src/assets/styles/cmps/_last-viewed.scss). Padding `32px 16px`, member info row gap 8px, avatar 26px.
+- **Lands in:** [05](05-workspaces-boards.md) (workspace landing page).
+- **Fidelity bar:** `match`.
+
+### 8.3 Favorites empty-state
+
+- **Legacy:** workspace-sidebar `.favorites-empty`. 80px star icon + centered text, font 15px, line-height 1.5.
+- **Lands in:** [05](05-workspaces-boards.md).
+- **Fidelity bar:** `match`.
+
+---
+
+## 9. Component → epic crosswalk
+
+A quick lookup of which epic owns which component.
+
+| Component / pattern | Epic |
+|---|---|
+| Tokens, fonts, scrollbar, `<MenuList />`, `<Skeleton />`, `<Logo />` | [01](01-foundation.md) |
+| `<LoginSignup />` form, marketing logo header | [03](03-auth.md) |
+| `<MainSidebar />`, `<WorkspaceSidebar />`, `<BoardHeader />` skeleton, `<CreateBoardModal />`, `<MemberModal />`, `<InviteModal />`, `<BoardDescriptionModal />`, `<LastViewed />`, favorites empty-state | [05](05-workspaces-boards.md) |
+| Inline-editable title pattern (board / group / task), `<GroupHeader />`, `<TaskRow />`, `<BulkActionBar />`, group color stripe + `<ColorPalette />`, group-menu / task-menu / add-group modals, "+ New Item" split-button skeleton | [06](06-groups-tasks-table.md) |
+| All cell types (`Status`, `Priority`, `Person`, `Date`, `Number`, `Checkbox`, `Text`, `Long-text`, `Email`, `Phone`, `Country`, `Link`, `Tags`, `Rating`, `Currency`, `Vote`, `Week`, `Location`, `Formula`, `UpdatedBy`, `CreatedBy`, `CreatedAt`), `<StatusLabelEditor />`, `<AddColumnModal />`, column header dropdown, group footer aggregations | [07](07-column-system.md) |
+| `<CommentList />`, `<CommentItem />`, `<ActivityList />`, `<ActivityItem />`, `<TaskDrawer />` shell + Updates / Activity tabs | [09](09-comments-activity.md) |
+| `<FileCell />`, `<TaskDrawer />` Files tab | [10](10-attachments.md) |
+| `<BoardFilter />` toolbar (`Filter`, `Sort`, `Hide`, `Group`, `Search` controls), saved-views tabs | [11](11-filtering-views.md) |
+| `<KanbanBoard />`, `<CalendarView />`, `<TimelineView />`, `<Dashboard />`, `<FormView />` and their per-view chrome (kanban card style, calendar agenda, timeline bars, dashboard widgets, form layout) | [12](12-alternate-views.md) |
+| `<NotificationBell />`, `<NotificationCenter />`, email templates | [13](13-notifications.md) |
+| Dark mode token overrides, `<EmptyState />`, mobile drawer + bottom-bar variants of `<MainSidebar />`/`<WorkspaceSidebar />`, motion-reduce wrappers | [14](14-mobile-a11y-polish.md) |
+
+---
+
+## 10. Open questions
+
+- **Mobile bottom-bar parity.** Legacy mobile mode for `<MainSidebar />` is non-trivial (fixed-bottom row, hidden tools, hamburger). Most of this lands in [14](14-mobile-a11y-polish.md), but the *desktop* version in [05](05-workspaces-boards.md) needs to leave room for it (component contract, not just CSS).
+- **Kanban code path.** Legacy Kanban is implemented but commented out of routing ([audit/03-frontend.md:32](../audit/03-frontend.md)). We're rebuilding from the SCSS + JSX, but treat any inferred behavior as design-by-archaeology.
+- **Custom date/time picker.** Legacy uses `react-datepicker` (chunk of CSS we'd inherit); new app should use Base UI's date primitives styled to the legacy chrome. Defer details to [07](07-column-system.md) cell spec.
+- **Status fold pixel-precise port.** The diagonal fold on hover is the most visually distinctive single moment in the app. Consider explicitly screenshotting it (light mode + dark mode) and saving to `docs/conversion-plan/_assets/` once produced, so executors don't drift.

--- a/docs/conversion-plan/design-system.md
+++ b/docs/conversion-plan/design-system.md
@@ -1,0 +1,521 @@
+# Donezo Design System (Locked)
+
+This document is the **canonical visual contract** for the new Next.js + Tailwind app. It is sourced verbatim from the legacy CRA + SCSS frontend at `frontend/` (kept locally per [CLAUDE.md](../../CLAUDE.md)). Every token here must round-trip into `app/globals.css` and `tailwind.config.ts` exactly as defined; new code must reference tokens, never hex literals.
+
+The legacy frontend is the **only** source of truth for color, type, spacing, motion, and component visuals. We are not redesigning the product. Where the legacy SCSS is silent or contradictory, this doc proposes a value and flags it (look for **GAP**).
+
+> Translation rules — read first:
+> - `frontend/` uses **SCSS variables**; we use **CSS custom properties** under Tailwind v4's `@theme`. The variable name maps 1:1 (e.g., `$workspace-hover` → `--color-workspace-hover`).
+> - SCSS `darken($color, 20%)` is a build-time function that doesn't exist in CSS. Wherever the legacy code calls `darken($border-color, 20%)` we **bake the result into a new token** (`--color-border-strong`) and use that. Do not attempt to recreate `darken()` at runtime.
+> - SCSS `rem($px)` and `em($px)` helpers convert px → rem against a 16px root. We use Tailwind's standard rem scale and the same conversions inline.
+> - Legacy uses `react-icons` (Bs/Ai/Bi/Hi/Tb sets) and `@mui/icons-material`. New app uses **Lucide React** as the single icon source; mapping table below. Match shape/weight, not the exact icon family.
+> - Legacy uses **MUI** + plain SCSS. New app uses **shadcn/ui (Base UI under the hood)**. We re-skin shadcn primitives with our tokens; we do not import MUI.
+
+---
+
+## 1. Color tokens
+
+### 1.1 Source map
+
+Every token below is lifted from `frontend/src/assets/styles/setup/_variables.scss`. The "Where" column is where the value already appears in legacy SCSS. The "New token" column is the CSS custom property name to add to `app/globals.css`. The "Tailwind class" column is the utility name once the token is wired into `@theme`.
+
+> **Marketing-page tokens removed.** The legacy SCSS contained a deep-indigo + electric-violet palette and three home-page gradients (`$home-bg`, `$home-btn-bg-gradient`, etc.) for the public landing page. Per [00-overview.md](00-overview.md), the new app drops marketing entirely — the only public surface is the Google sign-in. None of the marketing tokens carry over.
+
+#### 1.1.2 App surface
+
+| Legacy SCSS | Hex | Role | New CSS variable | Tailwind utility |
+|---|---|---|---|---|
+| `$app-bg` | `#ffffff` | Default surface (board, modals, cards) | `--color-surface` | `bg-surface` |
+| `$login-bg` | `#f7f7f7` | Auth-page wash ([_login-signup.scss:4](../../frontend/src/assets/styles/views/_login-signup.scss)) | `--color-surface-auth` | `bg-surface-auth` |
+| `$sidebar-workspace-bg` | `#F6F7FB` | Workspace sidebar (left rail content) | `--color-surface-rail` | `bg-surface-rail` |
+| `$sidebar-main-bg` | `#292f4c` | Main sidebar (icon column) — Monday-blue navy | `--color-surface-nav` | `bg-surface-nav` |
+| `$board-description-bg` | `#f5f6f8` | Right-pane in board description modal | `--color-surface-info` | `bg-surface-info` |
+| `$task-hover-color` | `#f4f5f8` | Row hover wash (task preview) | `--color-surface-row-hover` | `bg-surface-row-hover` |
+| `$workspace-hover` | `#dcdfec` | Hover state on sidebar items, menu rows, board tools | `--color-surface-hover` | `bg-surface-hover` |
+| `$workspace-board-active` | `#cce5ff` | Active board row in sidebar; "on-typing" cell highlight | `--color-surface-active` | `bg-surface-active` |
+| `$primary-selected-color` | `#cce5ff` | Selected primary chip bg (filter active state) | `--color-primary-selected` | `bg-primary-selected` |
+| `$primary-selected-hover-color` | `#aed4fc` | Hover on selected chip | `--color-primary-selected-hover` | `bg-primary-selected-hover` |
+| `$card-selected-background-color` | `#d9f0ff` | Selected member chip in filter modal | `--color-card-selected` | `bg-card-selected` |
+| `$member-modal-item-bg` | `#e5f4ff` | Member chip in member modal | `--color-chip-member` | `bg-chip-member` |
+
+#### 1.1.3 Primary action (Monday blue)
+
+This is the brand-anchor color of the app — used for primary buttons, active tabs, focus rings, comment-count badges, and "live edit" outlines. It must not drift.
+
+| Legacy SCSS | Hex | Role | New CSS variable | Tailwind utility |
+|---|---|---|---|---|
+| `$board-btn` | `#0073ea` | Primary action bg (New Item, Save), active-tab underline, focus outline | `--color-primary` | `bg-primary` / `text-primary` / `border-primary` |
+| `$primary-hover-color` | `#0060b9` | Primary hover (button + tab) | `--color-primary-hover` | `bg-primary-hover` |
+| `$link-color` | `#1f76c2` | Inline links inside body copy (board description) | `--color-link` | `text-link` |
+| `$text-color-on-primary` | `#ffffff` | Foreground over primary | `--color-primary-foreground` | `text-primary-foreground` |
+| `$menu-icon-color` | `#6c6cff` | Apps/menu glyph in main nav | `--color-nav-icon` | `text-nav-icon` |
+
+#### 1.1.4 Text & border
+
+| Legacy SCSS | Hex / value | Role | New CSS variable | Tailwind utility |
+|---|---|---|---|---|
+| `$primary-text-color` | `#323338` | Default body & heading text | `--color-fg` | `text-fg` |
+| `$workspace-icon-color` | `#676879` | Secondary text, sidebar icons, muted labels | `--color-fg-muted` | `text-fg-muted` |
+| `$chat-icon-color` | `#c5c7d0` | Inactive chat/comment icon | `--color-fg-subtle` | `text-fg-subtle` |
+| `$dark-black` | `#1f1f21` | Hard-contrast text (rare) | `--color-fg-strong` | `text-fg-strong` |
+| `$border-color` | `#d0d4e466` (40% alpha) | Soft cell/border lines | `--color-border` | `border-border` |
+| `$layout-border-color` | `#d0d4e4` | Solid layout borders, icon-hover wash | `--color-border-solid` | `border-border-solid` |
+| `darken($border-color, 20%)` | `#a8aebb` (baked) | Stronger cell borders, focus-visible outlines, divider lines — used pervasively in legacy | `--color-border-strong` | `border-border-strong` |
+| `darken($border-color, 30%)` | `#8c93a3` (baked) | Sidebar separator lines | `--color-border-rail` | `border-border-rail` |
+| `$task-box-shadow-color` | `#c3c6d4` | Task card shadow color, activity row separator | `--color-shadow-card` | (use in shadow tokens) |
+
+> **Why we bake `darken()`**: SCSS computes it at build time from a hex with 40% alpha; replicating it in CSS at runtime is brittle. The baked values above were computed by applying SCSS's HSL `darken` to the source. If a future change to `--color-border` is needed, recompute these and update.
+
+#### 1.1.5 Status / priority palette ("Monday colors")
+
+These five named colors are the canonical label palette. They map to default status labels (`Done`, `Working on it`, `Stuck`, etc.) and are referenced from `frontend/src/services/board.service.js`. This palette **must** seed the database in [02](02-supabase-schema.md).
+
+| Legacy name | Hex | Hover | Selected | Selected (60% α) | New CSS variable group |
+|---|---|---|---|---|---|
+| done-green | `#00c875` | `#0f9b63` | `#80e3ba` | `rgba(128,227,186,.6)` | `--color-label-green-*` |
+| egg_yolk | `#ffcb00` | `#c29e11` | `#ffe580` | — | `--color-label-yellow-*` |
+| bright-blue | `#579bfc` | `#4c7cc1` | `#abcdfd` | — | `--color-label-blue-*` |
+| explosive (gray) | `#c4c4c4` | `#98999a` | `#e1e1e1` | — | `--color-label-gray-*` |
+
+Additional label colors used in the default seed (`board.service.js`) but without `-hover`/`-selected` variants in SCSS:
+
+| Name | Hex | Used by default labels |
+|---|---|---|
+| working-orange | `#FDAB3D` | `Working on it`, `Medium` priority |
+| stuck-red | `#E2445C` | `Stuck`, `High` priority |
+| review-purple | `#A25DDC` | `Waiting for review` |
+| pending-blue | `#579BFC` | `Pending`, `Low` priority |
+| critical-black | `#333333` | `Critical` priority |
+
+**GAP**: legacy lacks formal hover/selected ramps for orange/red/purple/critical-black. Recommend deriving them in [02](02-supabase-schema.md) seed using the same SCSS pattern (≈15% darken for hover, ≈35% lighten for selected). Until then, use single-tone for hover (no shift) and same color at 50% alpha for selected.
+
+#### 1.1.6 Group color picker palette
+
+`frontend/src/services/util.service.js:65` defines the 12-color palette offered to users for group accents (the colored left-bar on each group):
+
+```
+#a25ddc  #FBBC04  #F1E4DE  #FDCFE8  #F28B82  #FFF475
+#CCFF90  #CBF0F8  #A7FFEB  #D7AEFB  #E6C9A8  #E8EAED
+```
+
+These should be exposed via `--color-group-1` through `--color-group-12` in `globals.css` so the [color-palette](#color-palette) component reads from tokens. Do not let users free-pick hex values — restrict to this palette to keep boards visually coherent.
+
+#### 1.1.7 Overlay & misc
+
+| Legacy SCSS | Value | Role | New CSS variable |
+|---|---|---|---|
+| `$react-modal-background` | `rgba(41, 47, 76, 0.7)` | Modal scrim (`.dark-screen`) | `--color-overlay` |
+
+> **GAP — dark mode**: legacy has no dark-mode tokens. Epic [14](14-mobile-a11y-polish.md) adds them. When generating dark variants, derive from the light tokens (do not reinvent the palette): invert `--color-fg`/`--color-surface`, dial back saturation on labels by ≈10%, keep `--color-primary` close to `#0073ea` (Monday's dark-mode primary is essentially unchanged).
+
+### 1.2 `app/globals.css` block (canonical)
+
+Drop this in `app/globals.css` under the existing `@theme`. Replace the placeholder palette installed in [01](01-foundation.md).
+
+```css
+@theme {
+  /* App surface */
+  --color-surface: #ffffff;
+  --color-surface-auth: #f7f7f7;
+  --color-surface-rail: #F6F7FB;
+  --color-surface-nav: #292f4c;
+  --color-surface-info: #f5f6f8;
+  --color-surface-row-hover: #f4f5f8;
+  --color-surface-hover: #dcdfec;
+  --color-surface-active: #cce5ff;
+  --color-primary-selected: #cce5ff;
+  --color-primary-selected-hover: #aed4fc;
+  --color-card-selected: #d9f0ff;
+  --color-chip-member: #e5f4ff;
+
+  /* Primary */
+  --color-primary: #0073ea;
+  --color-primary-hover: #0060b9;
+  --color-primary-foreground: #ffffff;
+  --color-link: #1f76c2;
+  --color-nav-icon: #6c6cff;
+
+  /* Text & border */
+  --color-fg: #323338;
+  --color-fg-muted: #676879;
+  --color-fg-subtle: #c5c7d0;
+  --color-fg-strong: #1f1f21;
+  --color-border: #d0d4e466;
+  --color-border-solid: #d0d4e4;
+  --color-border-strong: #a8aebb;   /* baked darken($border-color, 20%) */
+  --color-border-rail: #8c93a3;     /* baked darken($border-color, 30%) */
+  --color-shadow-card: #c3c6d4;
+
+  /* Labels (Monday palette) */
+  --color-label-green: #00c875;
+  --color-label-green-hover: #0f9b63;
+  --color-label-green-selected: #80e3ba;
+  --color-label-yellow: #ffcb00;
+  --color-label-yellow-hover: #c29e11;
+  --color-label-yellow-selected: #ffe580;
+  --color-label-blue: #579bfc;
+  --color-label-blue-hover: #4c7cc1;
+  --color-label-blue-selected: #abcdfd;
+  --color-label-gray: #c4c4c4;
+  --color-label-gray-hover: #98999a;
+  --color-label-gray-selected: #e1e1e1;
+  --color-label-orange: #FDAB3D;
+  --color-label-red: #E2445C;
+  --color-label-purple: #A25DDC;
+  --color-label-pending: #579BFC;
+  --color-label-critical: #333333;
+
+  /* Group accents (12) */
+  --color-group-1: #a25ddc;
+  --color-group-2: #FBBC04;
+  --color-group-3: #F1E4DE;
+  --color-group-4: #FDCFE8;
+  --color-group-5: #F28B82;
+  --color-group-6: #FFF475;
+  --color-group-7: #CCFF90;
+  --color-group-8: #CBF0F8;
+  --color-group-9: #A7FFEB;
+  --color-group-10: #D7AEFB;
+  --color-group-11: #E6C9A8;
+  --color-group-12: #E8EAED;
+
+  /* Overlay */
+  --color-overlay: rgba(41, 47, 76, 0.7);
+}
+```
+
+> **Tailwind v4 note**: Tailwind v4 reads `@theme` and auto-generates utilities. There is no separate `tailwind.config.ts` for tokens — but a `tailwind.config.ts` may still exist for plugins/content. Don't duplicate the tokens in JS; let `@theme` be the source.
+
+---
+
+## 2. Typography
+
+### 2.1 Fonts
+
+From `_variables.scss:82-83` and `_fonts.scss`:
+
+```scss
+$font-family: "Figtree", "Roboto", "Rubik", "Noto Kufi Arabic", "Noto Sans JP", sans-serif;
+$title-font-family: "Poppins", "Roboto", "Rubik", "Noto Kufi Arabic", "Noto Sans JP", sans-serif;
+```
+
+- **Body / UI:** Figtree (loaded from `frontend/src/assets/fonts/Figtree-Regular.ttf`)
+- **Headings / titles:** Poppins (loaded from `frontend/src/assets/fonts/Poppins-Regular.ttf`) — applied to `h1`–`h6` per [_base.scss:46](../../frontend/src/assets/styles/basics/_base.scss).
+
+> **GAP**: legacy ships only a single weight per family (`Regular`). `_base.scss` and component SCSS reference `font-weight: 500/600/700` freely — meaning legacy is silently falling back to the system font for non-400 weights. We **fix this in the new app** by loading variable fonts via `next/font/google`.
+
+#### 2.1.1 Loader (Next.js, in `app/layout.tsx`)
+
+```ts
+import { Figtree, Poppins } from 'next/font/google';
+
+const figtree = Figtree({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-sans',
+  display: 'swap',
+});
+
+const poppins = Poppins({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-display',
+  display: 'swap',
+});
+```
+
+Then in `globals.css`:
+
+```css
+@theme {
+  --font-sans: var(--font-sans), 'Roboto', 'Rubik', system-ui, sans-serif;
+  --font-display: var(--font-display), 'Roboto', 'Rubik', system-ui, sans-serif;
+}
+```
+
+`font-display` is applied to all `h1`–`h6`.
+
+### 2.2 Base sizes
+
+`_base.scss`:
+- `body { font-size: 18px; line-height: 1.6; }`
+- `html { line-height: 1.6; }`
+- All `h1`–`h6` use `--font-display` with no margin/padding reset values.
+
+> **Decision**: keep the 18px body baseline. Most app surfaces override down to 14px (table cells, modals) — see helper scale below. Don't cargo-cult Tailwind's 16px default; legacy boards visibly use 18px for prose.
+
+### 2.3 Helper / utility scale
+
+From `_helpers.scss` — these are the explicit sizes the legacy app uses. Match them in Tailwind utilities (Tailwind's `text-xs`/`text-sm`/`text-base` already cover most; expose the legacy-named ones too):
+
+| Legacy class | Size | Tailwind equivalent | Common usage |
+|---|---|---|---|
+| `.fs12` | 12px | `text-xs` | Comment counts, statistic sums |
+| `.fs14` | 14px | `text-sm` | Cell content, modal body, sidebar labels, comments |
+| `.fs18` | 18px | `text-lg` | Default body |
+| `.fs20` | 20px | `text-xl` | Section headers |
+| `.fs24` | 24px | `text-2xl` | Board title (narrow+) |
+| `.fs28` | 28px | `text-[28px]` | Modal headings |
+| `.fs30` | 30px | `text-3xl` | (legacy marketing only — unused in new app) |
+
+### 2.4 Weights (used in legacy)
+
+`400` (default body), `500` (sidebar items, board info, group titles, secondary headings), `600` (group titles, sidebar favorites title), `700` (logo). No use of 800/900.
+
+### 2.5 Line-heights
+
+- Body: `1.6` (set on `html` and `body`)
+- Board title (narrow+): `42px` (`_board-header.scss:234`)
+
+> **GAP**: legacy doesn't define a line-height token system. Use Tailwind's defaults (`leading-tight 1.25`, `leading-snug 1.375`, `leading-normal 1.5`, `leading-relaxed 1.625`) and reach for explicit pixel values only when a specific component spec demands it.
+
+---
+
+## 3. Spacing scale
+
+From `_variables.scss:73-79`:
+
+```scss
+$spacing-xs:    4px;
+$spacing-small: 8px;
+$spacing-medium:16px;
+$spacing-large: 24px;
+$spacing-xl:    32px;
+$spacing-xxl:   48px;
+$spacing-xxxl:  64px;
+```
+
+Tailwind's default scale (`1=4px, 2=8px, 4=16px, 6=24px, 8=32px, 12=48px, 16=64px`) already covers these 1:1. **Use Tailwind's numeric scale; don't introduce custom names.** A name-mapping cheatsheet for porting SCSS:
+
+| Legacy | Tailwind |
+|---|---|
+| `$spacing-xs` | `1` (4px) |
+| `$spacing-small` | `2` (8px) |
+| `$spacing-medium` | `4` (16px) |
+| `$spacing-large` | `6` (24px) |
+| `$spacing-xl` | `8` (32px) |
+| `$spacing-xxl` | `12` (48px) |
+| `$spacing-xxxl` | `16` (64px) |
+
+---
+
+## 4. Layout dimensions
+
+From SCSS, hard-coded constants that components depend on. These are part of the visual contract, not "magic numbers":
+
+| Token | Value | Used in |
+|---|---|---|
+| `$workspace-width` | `255px` | Workspace sidebar open width (also `230px` literal in `_workspace-sidebar.scss:11` — keep `230px`; `255` is dead) |
+| `$cell-height` | `36px` | All table cells (rows + headers) |
+| `$cell-width` | `140px` | Default column min-width |
+| `$cell-width-task` | `336px` | Task title column |
+| `$cell-width-person` | `140px` | Person column |
+| `$cell-width-conversation` | `65px` | Comments column |
+| `$cell-width-checkbox` | `32px` | Bulk-select column |
+| Main sidebar min width | `66px` | `_main-sidebar.scss:4` |
+| Workspace sidebar (open) | `230px` | `_workspace-sidebar.scss:11` |
+| Workspace sidebar (collapsed, narrow+) | `30px` | `_workspace-sidebar.scss:19` |
+| Mobile bottom nav height | `8vh` | `_main-sidebar.scss:111` |
+| Board header sticky offset | `0` (header) / `182–211px` (group/title) | `_group-preview.scss:39, 119` |
+
+Expose these as CSS variables (`--size-cell-h`, `--size-cell-w`, `--size-cell-w-task`, etc.) so we don't hard-code in component code.
+
+---
+
+## 5. Radii
+
+Legacy doesn't tokenize radii — it inlines them. Observed values:
+
+| Value | Where |
+|---|---|
+| `4px` | Cell focus outlines, board active row, buttons in modals, board tools, status fold edge |
+| `5px` | Primary action button (`.add-btn` board filter), task card kanban |
+| `6px` | Board tools, sticky-div task corners |
+| `8px` | Modals (dynamic-modal, board-modal), task card kanban inner, lightning workspace icon |
+| `10px` | Sidebar hover wash radius |
+| `25px` | Scrollbar thumb |
+| `50%` | Avatars, comment count, member chips |
+
+Lock to a tighter scale to clean this up:
+
+```css
+@theme {
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 10px;
+  --radius-pill: 9999px;
+}
+```
+
+Map: most cell/button corners → `--radius-xs`, board-tool corners → `--radius-sm`, modals → `--radius-md`, sidebar hover wash → `--radius-lg`, pills/avatars/CTA → `--radius-pill`.
+
+---
+
+## 6. Shadows
+
+Legacy inlines shadows too. Canonical values:
+
+| Token | Value | Where |
+|---|---|---|
+| `--shadow-modal` | `-3px 4px 14px rgb(0 0 0 / 20%)` | Dynamic modal, member modal, login-logout, create-board |
+| `--shadow-drawer` | `-6px 0px 14px rgb(0 0 0 / 20%)` | Board modal (right-side drawer when open) |
+| `--shadow-card` | `0px 4px 8px rgb(0 0 0 / 20%)` | Kanban task card |
+| `--shadow-bulk-bar` | `0px 15px 50px rgba(0, 0, 0, 0.3)` | Floating bulk-action bar |
+
+---
+
+## 7. Z-index layers
+
+Lock these as named layers — legacy uses raw integers liberally, which causes stacking bugs:
+
+| Layer | Value | Where used |
+|---|---|---|
+| `--z-base` | `0` | Default flow |
+| `--z-sticky` | `2` | Sticky group/task headers |
+| `--z-rail` | `10` | Login-logout, menu modal, dropdown chips |
+| `--z-board-header` | `30` | Board header sticky bar |
+| `--z-overlay` | `50` | Workspace toggle, dark-screen scrim |
+| `--z-modal` | `51` | Create-board, board-description |
+| `--z-drawer` | `100` | Board modal (right-side task drawer), invite modal, task-tools |
+| `--z-popover` | `1000` | dynamic-modal (cell pickers / menus) |
+
+Reference these in components (`z-[var(--z-modal)]`) instead of arbitrary integers.
+
+---
+
+## 8. Motion / micro-interactions
+
+Legacy is **not formally tokenized**, but a clear pattern emerges across SCSS. Lock these tokens to dedupe:
+
+### 8.1 Duration tokens
+
+| Token | Value | Derived from |
+|---|---|---|
+| `--motion-instant` | `100ms` | `add-btn` color shift `.1s` ([_group-preview.scss:75](../../frontend/src/assets/styles/cmps/group/_group-preview.scss)) |
+| `--motion-fast` | `150ms` | task-tools-modal opacity/transform `150ms` |
+| `--motion-base` | `200ms` | All `.2s` transitions: sidebar items, sidebar workspace open/close inner content, hover sidebar, board filter active, group title-info opacity |
+| `--motion-medium` | `300ms` | `.3s` transitions: sidebar icon-link bg, opacity ease |
+| `--motion-slow` | `400ms` | board-filter add-btn `.4s`; workspace-sidebar collapse/expand `.4s` |
+| `--motion-drawer` | `600ms` | board-modal (right-side drawer) transform `.6s` |
+
+### 8.2 Easing
+
+Legacy almost universally relies on browser default easing (`ease`) and a few explicit `ease-out`/`ease-in-out`. Standardize:
+
+| Token | Value | Use |
+|---|---|---|
+| `--ease-standard` | `cubic-bezier(0.4, 0, 0.2, 1)` | Default for color/bg/transform on hover |
+| `--ease-emphasized` | `cubic-bezier(0.2, 0, 0, 1)` | Drawer slide, sidebar collapse |
+| `--ease-out` | `cubic-bezier(0, 0, 0.2, 1)` | Status fold expand (`status-priority-picker`) |
+
+Tailwind v4 already supplies `ease-in`/`ease-out`/`ease-in-out`; expose the named tokens on top.
+
+### 8.3 Recurring micro-interaction patterns
+
+These are the visible "Monday-feel" moments. Components implementing them must match the timing, not just the visual.
+
+| Pattern | Spec | Source |
+|---|---|---|
+| **Row hover reveals** | Background `--color-surface-row-hover`, hidden controls (`task-menu .icon`, `open-task-details`, `add-number-icons`) opacity `0 → 1` over `--motion-base` | task-preview, group-preview, number-picker |
+| **Sidebar item hover** | `bg-color` shift to `--color-surface-hover`, radius `4px`, transition `--motion-base` | workspace-sidebar `.workspace-btns > * { transition: .2s }` |
+| **Workspace sidebar collapse** | Width animates `0 ↔ 230px` over `--motion-slow`; inner content opacity `0 ↔ 1` with `transition-delay: .25s` so it fades in *after* the rail finishes opening | _workspace-sidebar.scss:7-25 |
+| **Toggle workspace pill** | Hover grows horizontal padding (`8px → 16px`) and color-flips to `--color-primary` over `--motion-base` | _workspace-sidebar.scss:194-208 |
+| **Status pill "fold" reveal** | On status cell hover, a triangular fold grows from 0 → 10×10 → 15×15 px in the top-right corner, transitioning `border-width` over `--motion-base` with `transition-delay: .2s` | _status-priority-picker.scss:6-28 |
+| **Avatar shrink-on-hover** | Logged-user avatar in main sidebar `transform: scale(.9)` over `--motion-base` | _main-sidebar.scss:48-53 |
+| **Board "+ New Item" button** | Halves of split-button independently round their corners (5px) on hover over `--motion-slow`; bg → `--color-primary-hover` | _board-filter.scss:43-66 |
+| **Search expand** | Search input width `58 → 140px` over `--motion-medium` on focus; chrome border on focus uses `--color-primary` | _board-filter.scss:90-110 |
+| **Board drawer slide-in** | `transform: translateX(100% → 0)` over `--motion-drawer`, paired with shadow fade | _board-modal.scss:9-23 |
+| **Active-tab indicator** | 2px bottom border in `--color-primary`; no animated underline (snap-on) | _board-header.scss:155-157, _board-modal.scss:58-60 |
+| **Cell on-typing wash** | While editing: `bg-color` `--color-surface-active` (light blue `#cce5ff`) — signals "this cell is live" | _task-preview.scss:15-17, 128-131 |
+| **Focus outline** | `outline: 1px solid --color-primary` on inputs/contenteditable cells; hover preview uses `outline: 1px solid --color-border-strong` | _task-preview.scss:147-153 |
+| **Group color stripe** | 6px solid left border on `.sticky-div`, color = group's chosen accent. Defines the row's group identity visually | _group-preview.scss:299 |
+
+### 8.4 Reduced motion
+
+Legacy ignores `prefers-reduced-motion`. The new app must wrap any animation with duration > `--motion-base` in `@media (prefers-reduced-motion: no-preference)` — see [14](14-mobile-a11y-polish.md).
+
+---
+
+## 9. Iconography
+
+### 9.1 Source
+
+- Legacy: `react-icons` (Bs, Ai, Bi, Hi, Hi2, Tb sets) + `@mui/icons-material`. ~30+ icons used across the app.
+- New app: **Lucide React** (`lucide-react`). One library. No MUI.
+
+### 9.2 Mapping table
+
+Match shape and visual weight, not the exact icon family. Below is the mapping for icons that carry product meaning. Decorative icons can be re-picked freely from Lucide.
+
+| Legacy icon | Where used | Lucide equivalent |
+|---|---|---|
+| `BsFillLightningFill` | Workspace logo glyph (green tile) | `Zap` (filled) |
+| `BsCheckSquare` / `BsSquare` | Checkbox cell | `Check` / `Square` |
+| `BsBarChart` / `BsKanban` / `BsPersonCircle` | View tabs (Dashboard / Kanban / Person) | `BarChart3` / `Columns3` / `User` |
+| `BsStar` | Star/favorite | `Star` |
+| `BsPinAngle` | Pin | `Pin` |
+| `BsArrowDownCircle` / `BsArrowRightCircle` | Section navigation arrows | `CircleArrowDown` / `CircleArrowRight` |
+| `BsFillCircleFill` | Color-palette swatch | `Circle` (filled via `fill-current`) |
+| `BsFillPlusCircleFill` | Add-circle CTA | `CirclePlus` |
+| `BiDotsHorizontalRounded` | Row/group/board overflow menu | `MoreHorizontal` |
+| `BiMessageRoundedAdd` | "Add comment" cell affordance | `MessageSquarePlus` |
+| `BiLogIn` | Login | `LogIn` |
+| `AiOutlinePlus` | Add-button glyph (rotates 45° to become "X") | `Plus` (rotation already specced) |
+| `AiOutlineClose` / `AiFillCloseCircle` | Close button (modals, chips) | `X` / `XCircle` |
+| `AiOutlineSearch` | Search | `Search` |
+| `AiOutlineDelete` | Delete | `Trash2` |
+| `AiOutlineFileAdd` | File picker cell | `FilePlus` |
+| `AiOutlineBold` | Rich-text toolbar bold | `Bold` |
+| `AiOutlineStar` / `AiOutlineMenu` | Outline star, hamburger | `Star` (outline) / `Menu` |
+| `AiFillHome` | Home glyph (workspace icon overlay) | `Home` |
+| `HiOutlineChatBubbleOvalLeft` | Inactive comment indicator | `MessageCircle` |
+| `TbArrowsDiagonal` | "Open task" expand | `Maximize2` |
+
+> **Spacing & sizing**: legacy icons run `font-size: 16–28px` mapped to `rem()` units. In the new app, default Lucide size is `24px`; pass `size={20}` for inline cell glyphs and `size={16}` for badges/counts. Use `stroke-width={2}` (Lucide default) for everything except `Maximize2` and other expand affordances which look better at `1.5`.
+
+### 9.3 Custom assets
+
+The legacy logo is a PNG (`frontend/src/assets/img/logo.png`). For the new app, create an SVG version preserving the silhouette. Until then, place the PNG in `public/logo.png` and use `next/image`. **Do not** ship the legacy `loader.gif`; the new app uses `<Skeleton />` (see [14](14-mobile-a11y-polish.md)).
+
+---
+
+## 10. Scrollbar
+
+`_base.scss:1-20`:
+
+```css
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #878787 #D9D9D9;
+}
+*::-webkit-scrollbar { width: 8px; }
+*::-webkit-scrollbar-track { background: #D9D9D9; }
+*::-webkit-scrollbar-thumb {
+  border-radius: 25px;
+  background-color: #A6A5A5;
+}
+```
+
+Replicate verbatim in `globals.css`. The thin gray scrollbar is part of the visual identity — TanStack Virtual will inherit it.
+
+---
+
+## 11. Breakpoints
+
+From `_variables.scss:86-88` and `_mixins.scss:3-25`:
+
+| Legacy mixin | px | Tailwind class |
+|---|---|---|
+| `for-mobile-layout` | up to `460+40 = 500px` | `max-md:` (≤ 768) — *closest match* |
+| `for-narrow-layout` | from `500px` | `md:` (≥ 768) — *closest match* |
+| `for-normal-layout` | from `760px` | `lg:` (≥ 1024) — *closest match* |
+| `for-wide-layout` | from `1000px` | `xl:` (≥ 1280) — *closest match* |
+
+**Decision**: legacy breakpoints don't align with Tailwind's defaults and are smaller across the board. Use Tailwind defaults for the new app (`sm 640`, `md 768`, `lg 1024`, `xl 1280`, `2xl 1536`). The legacy breakpoints were CRA-era assumptions about a single-screen reality; the new app should target modern device classes. Mobile parity is a [14](14-mobile-a11y-polish.md) deliverable.
+
+---
+
+## 12. How this lands
+
+Implemented as an **epic 01 followup slice** ([`_dispatch/epic-01-followup-1.md`](_dispatch/epic-01-followup-1.md)) running before any further UI epic kicks off. After it merges, all subsequent UI epics (05+) consume this doc and [`component-system.md`](component-system.md) for their "Visual fidelity requirements" section — they never re-derive tokens.

--- a/lib/icons.ts
+++ b/lib/icons.ts
@@ -1,0 +1,40 @@
+/**
+ * Canonical icon module.
+ *
+ * The ONLY file allowed to import from `lucide-react`. All other code imports
+ * from `@/lib/icons`. Mapping back to legacy react-icons is documented in
+ * `docs/conversion-plan/design-system.md` §9.2.
+ */
+export {
+  // View kinds
+  BarChart3 as IconViewDashboard,
+  Bold as IconBold,
+  // Status / interaction
+  Check as IconCheck,
+  Circle as IconCircle,
+  CircleArrowDown as IconArrowDown,
+  CircleArrowRight as IconArrowRight,
+  CirclePlus as IconCirclePlus,
+  Columns3 as IconViewKanban,
+  FilePlus as IconFileAdd,
+  Home as IconHome,
+  LogIn as IconLogIn,
+  Maximize2 as IconExpand,
+  Menu as IconMenu,
+  MessageCircle as IconComment,
+  MessageSquarePlus as IconCommentAdd,
+  // Menus / overflow
+  MoreHorizontal as IconMore,
+  Pin as IconPin,
+  // Common actions
+  Plus as IconPlus,
+  Search as IconSearch,
+  Square as IconSquare,
+  Star as IconStar,
+  Trash2 as IconDelete,
+  User as IconViewPerson,
+  X as IconClose,
+  XCircle as IconCloseCircle,
+  // Workspace / brand
+  Zap as IconLightning,
+} from "lucide-react";


### PR DESCRIPTION
## Summary

Retrofits the epic 01 foundation substrate with the locked Monday-derived design system, sourced verbatim from the legacy `frontend/` SCSS. After this lands, every UI epic (05+) consumes canonical chrome — no per-epic re-skinning later.

Three commits on the followup branch:
- `50bb73f` — docs(conversion-plan): lock design system + component contracts; drop marketing
- `78185b2` — tokens(slice-i): globals.css canonical palette + Figtree/Poppins fonts (#37)
- `5e330fe` — feat(design-system): canonical icon re-exports + MenuList primitive [Slice J] (#38)

## What landed

- **Canonical Monday-derived palette** in `app/globals.css` `@theme` block: `#0073ea` primary, `#292f4c` nav, full label palette (green/yellow/blue/gray/orange/red/purple/pending/critical), all 12 group accents, overlay, layout sizes, radii, shadows, z-index layers, motion durations + easing — token-for-token match against `design-system.md §1.2`.
- **shadcn `:root` block rewired** to Monday values while preserving shadcn's variable names; `<Button>` now auto-renders Monday blue without JSX changes.
- **Legacy aliases preserved** (`--color-bg`, `--color-bg-subtle`, `--color-primary-fg`) as `var()` synonyms — six existing references across `app/` keep resolving.
- **Fonts:** Geist → Figtree (body) + Poppins (display) via `next/font/google`, weights 400/500/600/700.
- **Scrollbar + base typography** added to `@layer base`: thin gray Monday scrollbar, body 18px / line-height 1.6, h1–h6 use `--font-display`.
- **`lib/icons.ts`** — canonical `Icon*`-prefixed re-exports from `lucide-react` (26 icons covering every legacy icon enumerated in `design-system.md §9.2`).
- **`<MenuList />` + `<MenuListItem />`** primitive at `components/ui/menu-list.tsx` implementing the legacy `@mixin menu-modal()` recipe.
- **Locked specs** (`design-system.md`, `component-system.md`) added; visual-fidelity sections added to UI epics 01/05/06/07/09/11/12/14; marketing dropped from scope.

## Forbidden scope respected

- `components/ui/button.tsx` — untouched; Monday blue comes from token rewire.
- `components/ui/sonner.tsx` — untouched.
- `app/page.tsx` — untouched (legacy aliases held).
- `.dark` block in `globals.css` — untouched (epic 14 ownership).
- `@theme inline` block in `globals.css` — untouched (epic 14 ownership).
- All infra config (`package.json`, `pnpm-lock.yaml`, `tsconfig.json`, `biome.json`, `next.config.ts`, `tests/`) — untouched.

## Acknowledged carry-overs (not blockers)

- **`--font-mono` removed.** `app/page.tsx:13` uses `font-mono`; falls back to Tailwind v4's built-in mono stack. Add a brand mono later if desired.
- **`components/ui/sonner.tsx` still imports `lucide-react` directly** (5 icons). Deferred to epic 14 alongside theme-block reconciliation per spec.

## Process learning

Both slices flat-named their branches (`slice-i/01-followup-design-system`, `slice-j/01-followup-design-system`) instead of the spec's nested `epic/01-followup-design-system/slice-{i,j}` because git refuses to nest a branch under an existing leaf branch. Should fold this convention into the dispatch-spec template.

## Test plan

- [x] CI green on both slice PRs (#37, #38)
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm build` all green per slice
- [x] Reviewer (epic-researcher / Opus) verdict: **CLEAN**
- [ ] Manual smoke test on Vercel preview: Monday-blue Ping button + white surface + Figtree body + Poppins headings + thin gray scrollbar
- [ ] Manual smoke test: existing Sign-in flow still works (Slice I changed shadcn `:root` values that affect every shadcn primitive)

## References

- Dispatch spec: [`docs/conversion-plan/_dispatch/epic-01-followup-2.md`](docs/conversion-plan/_dispatch/epic-01-followup-2.md)
- Locked design system: [`docs/conversion-plan/design-system.md`](docs/conversion-plan/design-system.md)
- Locked component system: [`docs/conversion-plan/component-system.md`](docs/conversion-plan/component-system.md)
- Original epic: [`docs/conversion-plan/01-foundation.md`](docs/conversion-plan/01-foundation.md)
- Prior followup: [`docs/conversion-plan/_dispatch/epic-01-followup-1.md`](docs/conversion-plan/_dispatch/epic-01-followup-1.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)