### PR TITLE
Epic 08: Realtime & Presence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,3 +116,7 @@ Run these steps after epic 01 merges to `main`. These are human-executed steps â
 ## Custom domain
 
 TBD; deferred per epic 01 decision Q11. Tracked in the conversion plan. Preview deploys use Vercel's generated URLs until a domain is provisioned.
+
+## Realtime & writes
+
+Donezo's writes go through server actions only. Realtime is read-only on the client â€” postgres_changes events feed the Zustand store via idempotent `applyXxxUpsert` methods, gated on `updated_at`. Never write to the database directly from the client. Presence and broadcast (cursors, typing) are non-persistent advisory state; the server does not trust them.

--- a/app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions.ts
+++ b/app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions.ts
@@ -23,8 +23,15 @@
  *   time, but we only call it inside the action handler, at invocation time.
  *   Stage 3 real defs will be wired before these actions are invoked in production.
  *
- * Guardrail #20 — no board_id write:
- *   We never write `task.board_id`. The cell table only references `task_id`.
+ * Guardrail #20 — no task.board_id write:
+ *   We never write `task.board_id`. task.board_id is kept in sync by the
+ *   task_board_id_consistency trigger (initial schema, lines 398–408).
+ *
+ * Epic 08 — S0: cell.board_id denormalization:
+ *   Both upsert paths now include `board_id: col.board_id` in the payload so
+ *   Realtime postgres_changes can filter on board_id=eq.<id>. The
+ *   cell_board_id_consistency trigger overwrites this on the server, providing
+ *   defense-in-depth against any action that omits the field.
  */
 
 import { withUser } from "@/lib/actions";
@@ -74,12 +81,16 @@ export const setCellValue = withUser(async ({ supabase, userId }, raw) => {
   const patch = cellDef.toRow(input.value);
 
   // 5. Upsert the cell row.
+  //    board_id is included explicitly for Realtime postgres_changes filtering
+  //    (Epic 08 — S0). The cell_board_id_consistency trigger will overwrite it
+  //    on the server, but writing it from the action is faster and self-documenting.
   const { data, error } = await supabase
     .from("cell")
     .upsert(
       {
         task_id: input.taskId,
         column_id: input.columnId,
+        board_id: col.board_id,
         ...patch,
         updated_by: userId,
       },
@@ -169,9 +180,13 @@ export const bulkSetCellValue = withUser(async ({ supabase, userId }, raw) => {
   const patch = cellDef.toRow(input.value);
 
   // Step 6: Build the upsert payload for all taskIds.
+  //    board_id is included explicitly for Realtime postgres_changes filtering
+  //    (Epic 08 — S0). The cell_board_id_consistency trigger will overwrite it
+  //    on the server, but writing it from the action is faster and self-documenting.
   const upsertPayload = input.taskIds.map((tid) => ({
     task_id: tid,
     column_id: input.columnId,
+    board_id: col.board_id,
     ...patch,
     updated_by: userId,
   }));

--- a/app/(app)/w/[workspaceSlug]/b/[boardId]/groups/actions.ts
+++ b/app/(app)/w/[workspaceSlug]/b/[boardId]/groups/actions.ts
@@ -268,6 +268,7 @@ export const duplicateGroup = withUser(async ({ supabase, userId }, raw) => {
     const newTaskId = oldToNewTaskId.get(sourceCell.task_id);
     if (!newTaskId) continue; // should not happen
 
+    // @ts-expect-error: cell_board_id_consistency trigger sets board_id from task_id
     const { error: cellInsertError } = await supabase.from("cell").insert({
       task_id: newTaskId,
       column_id: sourceCell.column_id,

--- a/app/(app)/w/[workspaceSlug]/b/[boardId]/layout.tsx
+++ b/app/(app)/w/[workspaceSlug]/b/[boardId]/layout.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { BoardHeader } from "@/components/board/BoardHeader";
 import { BoardViewTabs } from "@/components/board/BoardViewTabs";
+import { requireUser } from "@/lib/auth/current-user";
 import { getBoardRole } from "@/lib/authorization";
 import { BoardProvider } from "@/lib/board-context";
 import { createClient } from "@/lib/supabase/server";
@@ -14,6 +15,9 @@ export default async function BoardLayout({
 }) {
   const { boardId } = await params;
   const supabase = await createClient();
+  // requireUser is used by BoardHeader too; calling here ensures userId is available
+  // for BoardProvider (consumed by useCursorBroadcast via useBoard — Epic 08 S6).
+  const currentUser = await requireUser();
 
   const { data: board } = await supabase
     .from("board")
@@ -36,7 +40,7 @@ export default async function BoardLayout({
   const isStarred = Boolean(starred);
 
   return (
-    <BoardProvider board={board} role={role} isStarred={isStarred}>
+    <BoardProvider board={board} role={role} isStarred={isStarred} userId={currentUser.id}>
       <div className="flex flex-col h-full min-h-0">
         <BoardHeader boardId={board.id} />
         <BoardViewTabs />

--- a/app/(app)/w/[workspaceSlug]/b/[boardId]/tasks/actions.ts
+++ b/app/(app)/w/[workspaceSlug]/b/[boardId]/tasks/actions.ts
@@ -202,6 +202,7 @@ export const duplicateTask = withUser(async ({ supabase, userId }, raw) => {
 
   // 5. INSERT cloned cells (per-cell loop — non-atomic, acceptable for v1).
   for (const sourceCell of cells) {
+    // @ts-expect-error: cell_board_id_consistency trigger sets board_id from task_id
     const { error: cellInsertError } = await supabase.from("cell").insert({
       task_id: newTask.id,
       column_id: sourceCell.column_id,
@@ -477,6 +478,7 @@ export const bulkDuplicateTasks = withUser(async ({ supabase, userId }, raw) => 
 
     // INSERT cloned cells.
     for (const sourceCell of cells) {
+      // @ts-expect-error: cell_board_id_consistency trigger sets board_id from task_id
       const { error: cellInsertError } = await supabase.from("cell").insert({
         task_id: newTask.id,
         column_id: sourceCell.column_id,

--- a/components/board/BoardHeader.tsx
+++ b/components/board/BoardHeader.tsx
@@ -1,4 +1,5 @@
 import { BoardHeaderClient } from "@/components/board/BoardHeaderClient";
+import { requireUser } from "@/lib/auth/current-user";
 import { createClient } from "@/lib/supabase/server";
 
 /**
@@ -9,6 +10,7 @@ import { createClient } from "@/lib/supabase/server";
  */
 export async function BoardHeader({ boardId }: { boardId: string }) {
   const supabase = await createClient();
+  const currentUser = await requireUser();
 
   // Step 1: fetch board_member rows for this board (limit 50; pagination deferred to epic 06)
   const { data: boardMembers } = await supabase
@@ -73,5 +75,11 @@ export async function BoardHeader({ boardId }: { boardId: string }) {
     createdByName = p?.display_name ?? p?.email ?? null;
   }
 
-  return <BoardHeaderClient members={members} createdByName={createdByName} />;
+  return (
+    <BoardHeaderClient
+      members={members}
+      createdByName={createdByName}
+      currentUserId={currentUser.id}
+    />
+  );
 }

--- a/components/board/BoardHeaderClient.tsx
+++ b/components/board/BoardHeaderClient.tsx
@@ -6,6 +6,9 @@ import { renameBoard } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/actions";
 import { BoardDescriptionModal } from "@/components/board/BoardDescriptionModal";
 import { BoardSettingsMenu } from "@/components/board/BoardSettingsMenu";
 import { BoardStarToggle } from "@/components/board/BoardStarToggle";
+import { ConnectionStatus } from "@/components/board/ConnectionStatus";
+import { OutboxBanner } from "@/components/board/OutboxBanner";
+import { PresencePile } from "@/components/board/PresencePile";
 import { EditableTitle } from "@/components/shared/EditableTitle";
 import { InviteModal } from "@/components/shared/InviteModal";
 import { MemberModal } from "@/components/shared/MemberModal";
@@ -25,9 +28,14 @@ type Member = {
 interface BoardHeaderClientProps {
   members: Member[];
   createdByName: string | null;
+  currentUserId: string; // new — provided by BoardHeader.tsx server component
 }
 
-export function BoardHeaderClient({ members, createdByName }: BoardHeaderClientProps) {
+export function BoardHeaderClient({
+  members,
+  createdByName,
+  currentUserId,
+}: BoardHeaderClientProps) {
   const { board } = useBoard();
   const [membersOpen, setMembersOpen] = useState(false);
   const [descriptionOpen, setDescriptionOpen] = useState(false);
@@ -128,6 +136,11 @@ export function BoardHeaderClient({ members, createdByName }: BoardHeaderClientP
             Description
           </button>
         </div>
+
+        {/* live presence — green-dotted avatars of users on this board right now (Epic 08) */}
+        <PresencePile members={memberStackItems} currentUserId={currentUserId} />
+        <ConnectionStatus />
+        <OutboxBanner />
 
         {/* Member avatar stack */}
         <MemberStack members={memberStackItems} max={4} size={24} className="ml-2" />

--- a/components/board/ConnectionStatus.tsx
+++ b/components/board/ConnectionStatus.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useBoardStore } from "@/stores/board-store";
+
+/**
+ * ConnectionStatus — renders nothing when connected; shows a pill when
+ * reconnecting or offline.
+ *
+ * - `reconnecting`: yellow pulsing dot + "Reconnecting…"
+ * - `offline`: red dot + offline message
+ *
+ * Uses role="status" + aria-live="polite" for accessibility.
+ *
+ * TODO: map dot colors to --color-warning / --color-danger once tokens are
+ * defined in design-system.md (currently using Tailwind yellow-500 / red-500).
+ *
+ * Epic 08: Realtime & Presence
+ */
+export function ConnectionStatus() {
+  const connection = useBoardStore((s) => s.connection);
+
+  if (connection === "connected") return null;
+
+  const isReconnecting = connection === "reconnecting";
+
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
+      style={{
+        backgroundColor: isReconnecting ? "#fef9c3" : "#fee2e2",
+        color: isReconnecting ? "#854d0e" : "#991b1b",
+      }}
+    >
+      {/* TODO: use var(--color-warning) / var(--color-danger) once tokens land */}
+      <span
+        aria-hidden
+        className={`h-2 w-2 rounded-full ${isReconnecting ? "animate-pulse bg-yellow-500" : "bg-red-500"}`}
+      />
+      {isReconnecting ? "Reconnecting…" : "You're offline. Changes will sync when you reconnect."}
+    </span>
+  );
+}

--- a/components/board/ConnectionStatus.tsx
+++ b/components/board/ConnectionStatus.tsx
@@ -26,6 +26,7 @@ export function ConnectionStatus() {
   return (
     <span
       role="status"
+      data-testid="connection-status"
       aria-live="polite"
       className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
       style={{

--- a/components/board/CursorOverlay.tsx
+++ b/components/board/CursorOverlay.tsx
@@ -63,6 +63,7 @@ export function CursorOverlay({ taskId, columnId }: CursorOverlayProps): ReactEl
       {visible.map((cursor) => (
         <span
           key={cursor.user_id}
+          data-testid="cursor-dot"
           style={{
             display: "inline-block",
             width: DOT_SIZE,

--- a/components/board/CursorOverlay.tsx
+++ b/components/board/CursorOverlay.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * CursorOverlay — renders colored dot indicators for remote users currently
+ * hovering or focusing the same cell.
+ *
+ * Reads the `cursors` Map from the board store; filters for entries that match
+ * (taskId, columnId); renders absolutely-positioned 8px dots in the cell's
+ * top-right corner. Caps at 3 visible dots plus a "+N" label for overflow.
+ *
+ * Accessibility: `role="presentation"` — these dots are non-interactive
+ * decorations; screen readers should not announce them.
+ * `pointer-events: none` — never interferes with cell interaction.
+ */
+
+import type { ReactElement } from "react";
+import { cursorColorForUser } from "@/lib/realtime/cursor-color";
+import { useBoardStore } from "@/stores/board-store";
+import type { CursorPayload } from "@/stores/types/realtime";
+
+interface CursorOverlayProps {
+  taskId: string;
+  columnId: string;
+}
+
+const MAX_VISIBLE = 3;
+const DOT_SIZE = 8; // px
+const DOT_OFFSET = 4; // px horizontal spacing between stacked dots
+
+export function CursorOverlay({ taskId, columnId }: CursorOverlayProps): ReactElement | null {
+  const cursors = useBoardStore((s) => s.cursors);
+
+  // Filter cursors matching this cell
+  const matches: CursorPayload[] = [];
+  for (const cursor of cursors.values()) {
+    if (cursor.task_id === taskId && cursor.column_id === columnId) {
+      matches.push(cursor);
+    }
+  }
+
+  if (matches.length === 0) return null;
+
+  const visible = matches.slice(0, MAX_VISIBLE);
+  const overflow = matches.length - MAX_VISIBLE;
+
+  return (
+    // Wrapper: positioned relative to the cell's `position: relative` container.
+    // pointer-events: none — never blocks cell clicks or keyboard events.
+    <div
+      role="presentation"
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        top: 2,
+        right: 2,
+        display: "flex",
+        alignItems: "center",
+        gap: DOT_OFFSET,
+        pointerEvents: "none",
+        zIndex: 1,
+      }}
+    >
+      {visible.map((cursor) => (
+        <span
+          key={cursor.user_id}
+          style={{
+            display: "inline-block",
+            width: DOT_SIZE,
+            height: DOT_SIZE,
+            borderRadius: "50%",
+            backgroundColor: cursorColorForUser(cursor.user_id),
+            flexShrink: 0,
+          }}
+        />
+      ))}
+      {overflow > 0 && (
+        <span
+          style={{
+            fontSize: 10,
+            lineHeight: 1,
+            color: "var(--color-fg-muted, #888)",
+            flexShrink: 0,
+          }}
+        >
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/components/board/OutboxBanner.tsx
+++ b/components/board/OutboxBanner.tsx
@@ -1,5 +1,22 @@
 "use client";
-// Implemented in S8. Returning null keeps the header layout stable for S3+S4 to wire.
+
+// TODO: map bg-yellow-100/text-yellow-900/border-yellow-300/bg-yellow-500 to
+// design-system warning tokens (var(--color-warning-bg) etc.) once tokens are
+// defined in design-system.md.
+
+import { useBoardStore } from "@/stores/board-store";
+
 export function OutboxBanner() {
-  return null;
+  const count = useBoardStore((s) => s.outbox.length);
+  if (count === 0) return null;
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="inline-flex items-center gap-2 px-3 py-1 text-xs rounded bg-yellow-100 text-yellow-900 border border-yellow-300"
+    >
+      <span className="inline-block w-2 h-2 rounded-full bg-yellow-500 animate-pulse" />
+      Syncing {count} pending change{count === 1 ? "" : "s"}…
+    </div>
+  );
 }

--- a/components/board/OutboxBanner.tsx
+++ b/components/board/OutboxBanner.tsx
@@ -1,0 +1,5 @@
+"use client";
+// Implemented in S8. Returning null keeps the header layout stable for S3+S4 to wire.
+export function OutboxBanner() {
+  return null;
+}

--- a/components/board/PresencePile.tsx
+++ b/components/board/PresencePile.tsx
@@ -39,6 +39,7 @@ export function PresencePile({ members, currentUserId, max = 4 }: PresencePilePr
     // biome-ignore lint/a11y/useSemanticElements: span role="group" is correct for a presentational avatar stack
     <span
       role="group"
+      data-testid="presence-pile"
       className="inline-flex items-center"
       aria-label={`${othersPresent.length} user${othersPresent.length !== 1 ? "s" : ""} viewing this board`}
     >
@@ -55,6 +56,7 @@ export function PresencePile({ members, currentUserId, max = 4 }: PresencePilePr
               <Tooltip.Trigger
                 render={
                   <span
+                    data-testid="presence-avatar"
                     style={index === 0 ? undefined : { marginLeft: -8 }}
                     className="relative inline-flex shrink-0"
                   />

--- a/components/board/PresencePile.tsx
+++ b/components/board/PresencePile.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Tooltip } from "@base-ui/react";
+
+import { Avatar } from "@/components/shared/Avatar";
+import { selectPresentUserIds, useBoardStore } from "@/stores/board-store";
+
+interface PresencePileProps {
+  members: Array<{
+    id: string;
+    displayName: string | null;
+    email: string | null;
+    avatarUrl: string | null;
+  }>;
+  currentUserId: string;
+  max?: number; // default 4 (matches existing MemberStack default)
+}
+
+/**
+ * PresencePile — shows live-now avatars with a green dot for users currently
+ * viewing this board. Deduped per user (multi-tab aware). Current user excluded.
+ *
+ * Epic 08: Realtime & Presence
+ */
+export function PresencePile({ members, currentUserId, max = 4 }: PresencePileProps) {
+  const presentIds = useBoardStore(selectPresentUserIds);
+
+  // Exclude the current user from the displayed pile
+  const othersPresent = presentIds.filter((id) => id !== currentUserId);
+
+  const memberMap = new Map(members.map((m) => [m.id, m]));
+
+  const visible = othersPresent.slice(0, max);
+  const surplus = othersPresent.length - visible.length;
+
+  if (othersPresent.length === 0) return null;
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: span role="group" is correct for a presentational avatar stack
+    <span
+      role="group"
+      className="inline-flex items-center"
+      aria-label={`${othersPresent.length} user${othersPresent.length !== 1 ? "s" : ""} viewing this board`}
+    >
+      <Tooltip.Provider delay={200}>
+        {visible.map((userId, index) => {
+          const member = memberMap.get(userId);
+          const displayName = member?.displayName ?? null;
+          const email = member?.email ?? null;
+          const avatarUrl = member?.avatarUrl ?? null;
+          const label = displayName ?? email ?? "Unknown user";
+
+          return (
+            <Tooltip.Root key={userId}>
+              <Tooltip.Trigger
+                render={
+                  <span
+                    style={index === 0 ? undefined : { marginLeft: -8 }}
+                    className="relative inline-flex shrink-0"
+                  />
+                }
+              >
+                <Avatar
+                  src={avatarUrl}
+                  displayName={displayName}
+                  email={email}
+                  size={24}
+                  borderColor="white"
+                />
+                {/* Green presence dot — 8px at bottom-right */}
+                {/* TODO: map to --color-success once token is defined in design-system.md */}
+                <span
+                  aria-hidden
+                  className="absolute bottom-0 right-0 h-2 w-2 rounded-full bg-green-500 ring-1 ring-white"
+                />
+              </Tooltip.Trigger>
+              <Tooltip.Portal>
+                <Tooltip.Positioner sideOffset={4}>
+                  <Tooltip.Popup className="rounded-md bg-[color:var(--color-fg-strong)] px-2 py-1 text-xs text-white shadow-sm z-[var(--z-popover)]">
+                    {label}
+                  </Tooltip.Popup>
+                </Tooltip.Positioner>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          );
+        })}
+        {surplus > 0 && (
+          // biome-ignore lint/a11y/useAriaPropsSupportedByRole: surplus count chip uses aria-label for screen reader clarity
+          <span
+            aria-label={`${surplus} more user${surplus !== 1 ? "s" : ""} viewing`}
+            style={{
+              width: 24,
+              height: 24,
+              marginLeft: -8,
+              fontSize: 11,
+              border: "1.6px solid white",
+              color: "var(--color-fg)",
+              backgroundColor: "white",
+            }}
+            className="inline-flex items-center justify-center rounded-full shrink-0 font-medium leading-none select-none"
+          >
+            +{surplus}
+          </span>
+        )}
+      </Tooltip.Provider>
+    </span>
+  );
+}

--- a/components/board/table/BoardTable.tsx
+++ b/components/board/table/BoardTable.tsx
@@ -6,10 +6,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { reorderColumn } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/columns/actions";
-import {
-  renameGroup,
-  reorderGroup,
-} from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/groups/actions";
+import { reorderGroup } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/groups/actions";
 import { moveTask } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/tasks/actions";
 import type { EditableTitleHandle } from "@/components/shared/EditableTitle";
 import { EditableTitle } from "@/components/shared/EditableTitle";
@@ -18,6 +15,7 @@ import { useBoardRealtime } from "@/hooks/use-board-realtime";
 import { useTableKeyboardNav } from "@/hooks/use-table-keyboard-nav";
 import { positionBetween } from "@/lib/positions";
 import { flushOutbox } from "@/lib/realtime/outbox";
+import { wrappedRenameGroup } from "@/lib/realtime/wrapped-actions";
 import { useBoardStore } from "@/stores/board-store";
 
 import { AddGroupFooter } from "./AddGroupFooter";
@@ -35,6 +33,17 @@ import { TaskRow } from "./TaskRow";
 import { TableKeyboardContext, useTableKeyboard } from "./table-keyboard-context";
 import { TableScrollContext } from "./table-scroll-context";
 import type { Group, TableData } from "./types";
+
+// isQueuedResult — type-narrowing guard for withOutbox's queued branch.
+// Kept local so it does not add a new export to lib/realtime/outbox.ts.
+function isQueuedResult(r: unknown): r is { queued: true } {
+  return (
+    r !== null &&
+    typeof r === "object" &&
+    "queued" in r &&
+    (r as { queued?: unknown }).queued === true
+  );
+}
 
 // ---------------------------------------------------------------------------
 // GroupHeaderRow — inline helper that renders the group chrome for the
@@ -155,7 +164,9 @@ function GroupHeaderRow({ group, taskCount }: GroupHeaderRowProps) {
     });
 
     startTransition(async () => {
-      const result = await renameGroup({ groupId: group.id, name: nextValue });
+      const result = await wrappedRenameGroup({ groupId: group.id, name: nextValue });
+      // Soft success — optimistic update already applied; outbox will flush on reconnect.
+      if (isQueuedResult(result)) return;
       if (!result.ok) {
         // Revert to the original group row.
         useBoardStore.getState().applyGroupUpsert({

--- a/components/board/table/BoardTable.tsx
+++ b/components/board/table/BoardTable.tsx
@@ -13,8 +13,11 @@ import {
 import { moveTask } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/tasks/actions";
 import type { EditableTitleHandle } from "@/components/shared/EditableTitle";
 import { EditableTitle } from "@/components/shared/EditableTitle";
+import { useBoard } from "@/hooks/use-board";
+import { useBoardRealtime } from "@/hooks/use-board-realtime";
 import { useTableKeyboardNav } from "@/hooks/use-table-keyboard-nav";
 import { positionBetween } from "@/lib/positions";
+import { flushOutbox } from "@/lib/realtime/outbox";
 import { useBoardStore } from "@/stores/board-store";
 
 import { AddGroupFooter } from "./AddGroupFooter";
@@ -243,6 +246,46 @@ export function BoardTable({ boardId, initial }: BoardTableProps) {
   const hydratedRef = useRef(false);
   const [isAddGroupOpen, setIsAddGroupOpen] = useState(false);
   const [, startTransition] = useTransition();
+
+  // ---------------------------------------------------------------------------
+  // Epic 08 — Realtime hook mount + outbox flush trigger
+  //
+  // userId is sourced from BoardContext (wired in layout.tsx via BoardProvider).
+  // This avoids re-plumbing through page.tsx; the layout already calls
+  // requireUser() and passes the id down through BoardProvider.
+  // ---------------------------------------------------------------------------
+  const { userId } = useBoard();
+
+  // Mount the board-scoped Realtime subscription (postgres_changes + presence +
+  // broadcast). This hook owns channel lifecycle; cleanup on unmount.
+  useBoardRealtime(boardId, userId);
+
+  // Flush any queued outbox entries on reconnect or when the browser comes
+  // back online. Two triggers:
+  //   1. window 'online' event — the browser regained network access.
+  //   2. Zustand store `connection` field transitions to 'connected' — the
+  //      Supabase channel re-established (may happen after router.refresh()).
+  //
+  // Note: Zustand v5 removed the two-argument subscribe(selector, listener) API.
+  // We use the full-state subscribe and track prev connection manually.
+  useEffect(() => {
+    const onOnline = () => {
+      void flushOutbox();
+    };
+    window.addEventListener("online", onOnline);
+
+    // Zustand v5: subscribe(listener) receives (state, prevState).
+    const unsub = useBoardStore.subscribe((state, prevState) => {
+      if (prevState.connection !== "connected" && state.connection === "connected") {
+        void flushOutbox();
+      }
+    });
+
+    return () => {
+      window.removeEventListener("online", onOnline);
+      unsub();
+    };
+  }, []);
 
   // Hydrate the store once on mount (StrictMode-safe ref guard prevents
   // double-hydration from the dev-mode double-invocation of effects).

--- a/components/board/table/BulkActionBar.tsx
+++ b/components/board/table/BulkActionBar.tsx
@@ -29,7 +29,6 @@ import { ArrowRightLeft, Columns3, Copy, Trash2, X } from "lucide-react";
 import { useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 
-import { bulkSetCellValue } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions";
 import {
   bulkDeleteTasks,
   bulkDuplicateTasks,
@@ -38,7 +37,19 @@ import {
 import { CELL_TYPE_ICONS } from "@/lib/cells/icons";
 import { getCellDef } from "@/lib/cells/registry";
 import type { CellRow, CellTypeId } from "@/lib/cells/types";
+import { wrappedBulkSetCellValue } from "@/lib/realtime/wrapped-actions";
 import { useBoardStore } from "@/stores/board-store";
+
+// isQueuedResult — type-narrowing guard for withOutbox's queued branch.
+// Kept local so it does not add a new export to lib/realtime/outbox.ts.
+function isQueuedResult(r: unknown): r is { queued: true } {
+  return (
+    r !== null &&
+    typeof r === "object" &&
+    "queued" in r &&
+    (r as { queued?: unknown }).queued === true
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Bulk-settable column types (Q10)
@@ -385,11 +396,14 @@ export function BulkActionBar() {
     resetApplyState();
 
     startTransition(async () => {
-      const result = await bulkSetCellValue({
+      const result = await wrappedBulkSetCellValue({
         taskIds,
         columnId: col.id,
         value,
       });
+
+      // Soft success — optimistic update already applied; outbox will flush on reconnect.
+      if (isQueuedResult(result)) return;
 
       if (result.ok) {
         // Reconcile with server-returned cells

--- a/components/board/table/TaskTitleCell.tsx
+++ b/components/board/table/TaskTitleCell.tsx
@@ -3,8 +3,19 @@
 import { useEffect, useRef, useTransition } from "react";
 import { toast } from "sonner";
 
-import { renameTask } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/tasks/actions";
+// isQueuedResult — type-narrowing guard for withOutbox's queued branch.
+// Kept local so it does not add a new export to lib/realtime/outbox.ts.
+function isQueuedResult(r: unknown): r is { queued: true } {
+  return (
+    r !== null &&
+    typeof r === "object" &&
+    "queued" in r &&
+    (r as { queued?: unknown }).queued === true
+  );
+}
+
 import { EditableTitle, type EditableTitleHandle } from "@/components/shared/EditableTitle";
+import { wrappedRenameTask } from "@/lib/realtime/wrapped-actions";
 import { useBoardStore } from "@/stores/board-store";
 
 import { useTableKeyboard } from "./table-keyboard-context";
@@ -49,7 +60,9 @@ export function TaskTitleCell({ task }: TaskTitleCellProps) {
       .applyTaskUpsert({ ...task, title: next, updated_at: new Date().toISOString() });
 
     startTransition(async () => {
-      const result = await renameTask({ taskId: task.id, title: next });
+      const result = await wrappedRenameTask({ taskId: task.id, title: next });
+      // Soft success — optimistic update already applied; outbox will flush on reconnect.
+      if (isQueuedResult(result)) return;
       if (!result.ok) {
         // Revert to the original task row.
         useBoardStore.getState().applyTaskUpsert({ ...task, updated_at: new Date().toISOString() });

--- a/components/cells/CellEditor.tsx
+++ b/components/cells/CellEditor.tsx
@@ -25,12 +25,25 @@
 import { Popover } from "@base-ui/react";
 import { useEffect, useRef, useTransition } from "react";
 import { toast } from "sonner";
-import { setCellValue } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions";
 import type { Column, Task } from "@/components/board/table/types";
 import { getCellDef } from "@/lib/cells/registry";
 import type { CellTypeId } from "@/lib/cells/types";
+import { wrappedSetCellValue } from "@/lib/realtime/wrapped-actions";
 import { createClient } from "@/lib/supabase/client";
 import { useBoardStore } from "@/stores/board-store";
+
+// ---------------------------------------------------------------------------
+// isQueuedResult — type-narrowing guard for withOutbox's queued branch.
+// Kept local so it does not add a new export to lib/realtime/outbox.ts.
+// ---------------------------------------------------------------------------
+function isQueuedResult(r: unknown): r is { queued: true } {
+  return (
+    r !== null &&
+    typeof r === "object" &&
+    "queued" in r &&
+    (r as { queued?: unknown }).queued === true
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Derived types — editors never open for these; the orchestrator closes
@@ -126,7 +139,9 @@ function CellEditorInner({ task, column, onClose }: CellEditorProps) {
 
     // 5. Fire server action (in transition for non-blocking UI).
     startTransition(async () => {
-      const result = await setCellValue({ taskId: task.id, columnId: column.id, value });
+      const result = await wrappedSetCellValue({ taskId: task.id, columnId: column.id, value });
+      // Soft success — optimistic update already applied; outbox will flush on reconnect.
+      if (isQueuedResult(result)) return;
       if (result.ok) {
         useBoardStore.getState().applyCellUpsert(result.data);
       } else {

--- a/components/cells/TableCell.tsx
+++ b/components/cells/TableCell.tsx
@@ -67,7 +67,7 @@ function TableCellInner({ task, column }: TableCellProps) {
 
   return (
     // Relative wrapper required for CursorOverlay's absolute positioning.
-    <div className="relative">
+    <div className="relative" data-task-id={task.id} data-column-id={column.id}>
       <button
         type="button"
         onClick={() => setEditing(true)}

--- a/components/cells/TableCell.tsx
+++ b/components/cells/TableCell.tsx
@@ -15,10 +15,17 @@
  * compatibility allows extra props; each Cell component declares them as
  * optional in its own interface. We cast the component ref to accept
  * `Record<string, unknown>` at the one JSX call site to avoid spreading `as any`.
+ *
+ * Epic 08 S6: on mouseenter/focus, broadcasts the current user's cursor to
+ * other board participants via useCursorBroadcast. CursorOverlay renders other
+ * users' cursor dots inside the cell's top-right corner.
  */
 
 import { memo, useState } from "react";
+import { CursorOverlay } from "@/components/board/CursorOverlay";
 import type { Column, Task } from "@/components/board/table/types";
+import { useBoard } from "@/hooks/use-board";
+import { useCursorBroadcast } from "@/hooks/use-cursor-broadcast";
 import { getCellDef } from "@/lib/cells/registry";
 import type { CellTypeId } from "@/lib/cells/types";
 import { useBoardStore } from "@/stores/board-store";
@@ -41,6 +48,13 @@ function TableCellInner({ task, column }: TableCellProps) {
   const value = def.fromRow(cellRow as any);
   const config = (column.settings ?? {}) as never;
 
+  // Epic 08 S6: cursor broadcast.
+  // boardId is read from the store (hydrated at board mount time).
+  const boardId = useBoardStore((s) => s.boardId);
+  // userId comes from BoardContext — populated by the layout server component.
+  const { userId } = useBoard();
+  const { emit } = useCursorBroadcast(boardId ?? "", userId);
+
   if (editing) {
     return <CellEditor task={task} column={column} onClose={() => setEditing(false)} />;
   }
@@ -52,25 +66,32 @@ function TableCellInner({ task, column }: TableCellProps) {
   const CellComponent = def.Cell as React.ComponentType<any>;
 
   return (
-    <button
-      type="button"
-      onClick={() => setEditing(true)}
-      className="cursor-pointer w-full text-left p-0 border-0 bg-transparent"
-      aria-label={`Edit ${column.name ?? column.type} cell`}
-    >
-      {/*
-        columnId — StatusCell / PriorityCell use this for label lookup
-        members  — PersonCell / UpdatedByCell / CreatedByCell use this for avatar resolution;
-                   undefined here → cells fall back to count-badge or initials display
-      */}
-      <CellComponent
-        value={value}
-        config={config}
-        row={task}
-        columnId={column.id}
-        members={undefined}
-      />
-    </button>
+    // Relative wrapper required for CursorOverlay's absolute positioning.
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setEditing(true)}
+        onMouseEnter={() => emit(task.id, column.id)}
+        onFocus={() => emit(task.id, column.id)}
+        className="cursor-pointer w-full text-left p-0 border-0 bg-transparent"
+        aria-label={`Edit ${column.name ?? column.type} cell`}
+      >
+        {/*
+          columnId — StatusCell / PriorityCell use this for label lookup
+          members  — PersonCell / UpdatedByCell / CreatedByCell use this for avatar resolution;
+                     undefined here → cells fall back to count-badge or initials display
+        */}
+        <CellComponent
+          value={value}
+          config={config}
+          row={task}
+          columnId={column.id}
+          members={undefined}
+        />
+      </button>
+      {/* Cursor overlay — renders other users' colored dots in cell top-right */}
+      <CursorOverlay taskId={task.id} columnId={column.id} />
+    </div>
   );
 }
 

--- a/docs/conversion-plan/_dispatch/epic-08-followup-1.md
+++ b/docs/conversion-plan/_dispatch/epic-08-followup-1.md
@@ -1,0 +1,251 @@
+# Epic 08 — Followup Round 1
+
+## Review summary
+
+- Stage reviewed: `6112e2d..epic/08-realtime-presence` (all 8 slices merged).
+- Verdict: FOLLOWUP REQUIRED
+- Definition-of-done items met:
+  - Postgres changes filtered per-board for `task`, `cell`, `group`, `column` (comment correctly deferred).
+  - `board_id` denormalized on `cell` + `comment` with consistency triggers; migration + actions update correct.
+  - Idempotent applies on `updated_at` (existing from Epic 06, intact).
+  - Connection status indicator component exists with correct DOM behavior (`null` when connected, pill when not).
+  - PresencePile component implements multi-tab dedupe via `selectPresentUserIds`.
+  - Reconnect refetch uses `router.refresh()` on `reconnecting → SUBSCRIBED` (verified in `hooks/use-board-realtime.ts:182-189`).
+  - `useBoardRealtime` mounts at board level via `BoardTable.tsx:261` (survives view switches in Epic 12 because BoardTable is per-view; documented risk acceptable for v1).
+  - Hidden-tab pause for cursor + typing emit (`document.visibilityState !== 'visible'` gate in both broadcast hooks).
+  - CONTRIBUTING.md "Realtime & writes" note present.
+  - Cell DELETE handled correctly via parent-cascade in `applyTaskDelete` / `applyColumnDelete` / `applyGroupDelete`.
+  - Outbox `outboxOverflow` is reset on flush (`lib/realtime/outbox.ts:124`).
+  - `OutboxActionId` union matches registry (`renameTask` kept; `updateTaskFields` correctly removed with documentation).
+  - Test infrastructure pattern (`describe.skip` + `@ts-expect-error vitest`) matches established repo convention.
+- Definition-of-done items NOT met:
+  - "Offline write queue: upsert-only, localStorage, last-write-wins, **banner UI**, **flush on reconnect**" — plumbing exists but is unwired. No call site uses `withOutbox`; the outbox is dead code at runtime.
+  - "Two browsers on the same board see each other's cell edits, task adds, group reorders, comment posts within ~1s" — e2e cannot verify because selectors don't match DOM.
+  - "Avatar pile shows everyone currently viewing the board" — component is correct but e2e selectors won't find it.
+  - "Cursor dots ... work in the table" — e2e selectors broken.
+- Other issues found:
+  - `useTypingBroadcast` (`hooks/use-typing-broadcast.ts:62, 67-68`) calls `channel.subscribe()`, `channel.unsubscribe()`, and `supabase.removeChannel(channel)` on the **shared** board channel. When the hook unmounts, it tears down the channel for `useBoardRealtime` and `useCursorBroadcast` too — silently killing all realtime for the board. Latent today (no production caller); will explode the moment Epic 09's CommentComposer mounts.
+
+## Followup slices
+
+Three surgical fixes. Slices A and B can run in parallel; slice C touches multiple mutation sites and is sequenced last.
+
+---
+
+### Slice A: Fix `useTypingBroadcast` channel lifecycle
+
+**Owner:** epic-executor (sonnet)
+**Branch:** `epic/08-realtime-presence/followup-1-typing-channel-lifecycle`
+
+**Owns (write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/hooks/use-typing-broadcast.ts`
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/use-typing-broadcast.test.ts`
+
+**Reads (no write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/hooks/use-cursor-broadcast.ts` (canonical pattern for emit-only broadcast hook)
+- `/Volumes/SSD1T/DEV WORK/donezo/hooks/use-board-realtime.ts` (owns shared channel lifecycle)
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/channel.ts`
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/throttle.ts`
+
+**Forbidden:** Any other file. Do not touch `useBoardRealtime` or `useCursorBroadcast`.
+
+**Depends on:** none — parallel-safe with B and C.
+
+**Spec:**
+
+The current implementation of `useTypingBroadcast` calls `channel.subscribe()` on mount and `channel.unsubscribe()` + `supabase.removeChannel(channel)` on unmount. The board's realtime channel is owned by `useBoardRealtime`; tearing it down here kills postgres_changes, presence, and cursor broadcast for the entire board. The cursor hook gets this right — mirror that exactly.
+
+Required behavior, matching `useCursorBroadcast`:
+
+1. Acquire the channel via `supabase.channel(boardChannelName(boardId))`. Do NOT pass a config object; do NOT call `.subscribe()`. The channel is already subscribed by `useBoardRealtime`; Supabase's client deduplicates by topic.
+2. Keep the throttled emit and visibility gate.
+3. On unmount, **only** call `throttledRef.current?.cancel()`. Do NOT call `channel.unsubscribe()`. Do NOT call `supabase.removeChannel(channel)`. `useBoardRealtime` owns the lifecycle.
+4. Add a comment above the cleanup mirroring `use-cursor-broadcast.ts:14-15`:
+   ```ts
+   // useBoardRealtime owns channel lifecycle; we only cancel pending sends here.
+   ```
+
+**Tests (update `tests/unit/use-typing-broadcast.test.ts`):**
+
+- Remove the test at lines 230-239 (`"unmount calls channel.unsubscribe() and supabase.removeChannel()"`) — it codifies the bug.
+- Replace with a test `"unmount does NOT call channel.unsubscribe() or supabase.removeChannel() — board channel is owned by useBoardRealtime"`:
+  - After `unmount()`, assert `stubChannel.unsubscribe` was NOT called (`toHaveBeenCalledTimes(0)`).
+  - Assert `mockRemoveChannel` was NOT called.
+- Keep the existing test that asserts `send.cancel()` runs on unmount (the trailing-call suppression test at the surrounding lines).
+- Also verify: hook does NOT call `channel.subscribe()` on mount (assert `stubChannel.subscribe.toHaveBeenCalledTimes(0)`).
+- Existing throttle, visibility, and payload-shape tests should continue to pass against the updated implementation.
+
+**Definition of done:**
+- `use-typing-broadcast.ts` mirrors `use-cursor-broadcast.ts`'s cleanup pattern exactly.
+- No production code path can tear down the shared board channel from outside `useBoardRealtime`.
+- Tests assert the correct (non-destructive) lifecycle.
+- `pnpm typecheck` clean.
+
+**Escalation triggers:**
+- If you find another emit-only hook that also misuses the channel lifecycle, surface it; do not silently fix outside this slice's owns.
+
+---
+
+### Slice B: Wire e2e selectors via `data-testid` on components + cells
+
+**Owner:** epic-executor (sonnet)
+**Branch:** `epic/08-realtime-presence/followup-1-e2e-testids`
+
+**Owns (write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/PresencePile.tsx`
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/ConnectionStatus.tsx`
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/CursorOverlay.tsx`
+- `/Volumes/SSD1T/DEV WORK/donezo/components/cells/TableCell.tsx`
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/PresencePile.test.tsx` (update selectors if any current tests query DOM; otherwise leave)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/ConnectionStatus.test.tsx` (same)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/e2e/08-realtime.spec.ts` (only if a selector still needs adjusting after attributes land — verify, don't rewrite)
+
+**Reads (no write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/table/TaskRow.tsx` (note: already carries `data-task-id` on the row; do NOT add another)
+
+**Forbidden:** Any file outside the owns list. Do not refactor component internals; this is selector wiring only.
+
+**Depends on:** none — parallel-safe with A and C.
+
+**Spec:**
+
+The Playwright spec at `tests/e2e/08-realtime.spec.ts` uses four `data-testid` selectors plus a compound `[data-task-id][data-column-id]` selector. None of them currently match DOM. Add the missing attributes with minimal surgery.
+
+1. **`PresencePile.tsx`** —
+   - On the outer `<span role="group">` (currently line 40-44), add `data-testid="presence-pile"`.
+   - On each visible avatar's `Tooltip.Trigger`'s rendered `<span>` (the one with `style={index === 0 ? undefined : { marginLeft: -8 }}`, currently line 57-61), add `data-testid="presence-avatar"`. Do not add it to the `+N` surplus chip.
+
+2. **`ConnectionStatus.tsx`** —
+   - On the visible `<span role="status">` (currently line 27-43), add `data-testid="connection-status"`.
+   - When the component returns `null` (connected state, line 22), no testid is needed.
+
+3. **`CursorOverlay.tsx`** —
+   - On each rendered dot `<span>` inside `visible.map((cursor) => ...)` (currently lines 63-75), add `data-testid="cursor-dot"`.
+   - The wrapper `<div role="presentation">` does NOT need a testid; the e2e counts dot elements.
+
+4. **`TableCell.tsx`** —
+   - The e2e uses `[data-task-id="<t>"][data-column-id="<c>"]` as a SINGLE element selector. Today `data-task-id` is on `TaskRow` and `data-column-id` is only on `ColumnHeader`; no cell carries both. Add **both** `data-task-id={task.id}` and `data-column-id={column.id}` to the existing wrapper `<div className="relative">` (currently line 70). Do not change className or layout. Preserve the `<CursorOverlay />` and `<button>` children unchanged.
+
+**Tests:**
+
+- Component unit tests (`PresencePile.test.tsx`, `ConnectionStatus.test.tsx`) should continue to pass unchanged unless they queried the same nodes with different selectors. Verify by reading the test files; if they pass without modification, leave them alone.
+- The Playwright spec at `tests/e2e/08-realtime.spec.ts` should be left as-is unless a selector mismatch remains. The selectors are: `[data-testid='presence-pile']`, `[data-testid='presence-avatar']`, `[data-testid='connection-status']`, `[data-testid='cursor-dot']`, and `[data-task-id="<id>"][data-column-id="<id>"]`. After this slice, all five resolve to real DOM nodes.
+
+**Definition of done:**
+- All five e2e selectors resolve to real DOM nodes.
+- No layout, styling, accessibility, or behavior change to any component.
+- Existing unit tests still pass (verify by reading them; do not run them).
+- `pnpm typecheck` clean.
+
+**Escalation triggers:**
+- If a unit test currently asserts the absence of these data attributes, stop and report — that would mean a deliberate design choice we're about to violate.
+
+---
+
+### Slice C: Wire outbox into mutation call sites
+
+**Owner:** epic-executor (sonnet)
+**Branch:** `epic/08-realtime-presence/followup-1-outbox-wiring`
+
+**Owns (write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/components/cells/CellEditor.tsx` (wrap `setCellValue` call)
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/table/TaskTitleCell.tsx` (wrap `renameTask` call)
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/table/BoardTable.tsx` (wrap `renameGroup` call at the `GroupHeaderRow.handleRename` site — line 158)
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/table/BulkActionBar.tsx` (wrap `bulkSetCellValue` call at line 388)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/outbox-wiring.test.tsx` (new — verifies each call site goes through `withOutbox`)
+
+**Reads (no write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/outbox.ts` (`withOutbox` signature + behavior)
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/outbox-registry.ts` (registry; confirm action ids match)
+- `/Volumes/SSD1T/DEV WORK/donezo/stores/types/realtime.ts` (`OutboxActionId` union)
+
+**Forbidden:** Any server-action file. Any new export from `outbox.ts`. Do not change the `withOutbox` signature.
+
+**Depends on:** Slice A and Slice B may merge in either order; this slice should sequence after both to avoid editing `BoardTable.tsx` in parallel with B (B does not edit BoardTable, but C does). In practice: run C after Stage 1's A+B parallel pass merges.
+
+> Orchestrator note: A and B don't touch `BoardTable.tsx` or any of C's owned files, so A+B+C can theoretically all run in parallel. However, recent epic history shows BoardTable edits collide frequently; sequencing C after A+B is the safer schedule.
+
+**Spec:**
+
+The outbox plumbing (`withOutbox`, `flushOutbox`, registry, banner) exists but is never invoked because no mutation site is wrapped. The DoD bullet "Offline write queue: ... banner UI, flush on reconnect" requires the four upsert-style call sites to go through `withOutbox`. Wrap each one with the matching `OutboxActionId`.
+
+**General pattern at each call site:**
+
+Before (today):
+```ts
+const result = await setCellValue({ taskId, columnId, value });
+```
+
+After:
+```ts
+const wrappedSetCellValue = withOutbox("setCellValue", setCellValue);
+const result = await wrappedSetCellValue({ taskId, columnId, value });
+```
+
+Two implementation notes:
+
+- `withOutbox` returns `(...args) => Promise<TReturn | { queued: true }>`. Caller code must handle the `queued: true` branch: treat it as a soft success — the optimistic update already applied locally, and the outbox will replay on reconnect. Do NOT call the existing rollback path on `queued: true`; only on a thrown error.
+- The wrapped function should be created **once** per call site (module-level constant or memoized via `useMemo`), not on every render. `withOutbox` itself is stable; the returned function captures the action reference at wrap-time.
+
+**Per-site instructions:**
+
+1. **`components/cells/CellEditor.tsx`** (line 129 — `setCellValue`):
+   - Import `withOutbox` from `@/lib/realtime/outbox` and `setCellValue` (already imported).
+   - At module scope (outside any component): `const wrappedSetCellValue = withOutbox("setCellValue", setCellValue);`
+   - Replace `await setCellValue(...)` with `await wrappedSetCellValue(...)`.
+   - In the success branch (the existing `if (result.ok) { ... }` or equivalent — read the file to confirm shape), add a guard: if the result indicates `queued: true` (i.e. the result is `{ queued: true }` rather than the normal `{ ok, data }` shape), treat as success and skip any explicit "server returned canonical row" reconciliation (the optimistic update already applied). Do not toast.
+   - On thrown error, the existing toast/rollback runs unchanged.
+
+2. **`components/board/table/TaskTitleCell.tsx`** (line 52 — `renameTask`):
+   - Same pattern. Module-level `wrappedRenameTask`. Handle `queued: true` as soft success.
+
+3. **`components/board/table/BoardTable.tsx`** (line 158 — `renameGroup` inside `GroupHeaderRow.handleRename`):
+   - Same pattern. Module-level `wrappedRenameGroup`. Handle `queued: true`.
+   - Do not touch the realtime mount effect or outbox flush trigger at lines 251-288.
+
+4. **`components/board/table/BulkActionBar.tsx`** (line 388 — `bulkSetCellValue`):
+   - Same pattern. Module-level `wrappedBulkSetCellValue`. Handle `queued: true`.
+
+**Result-shape detection.** `withOutbox` returns either the action's original return or `{ queued: true }`. The simplest discriminator at the call site is:
+```ts
+const result = await wrappedAction(args);
+if (result && typeof result === "object" && "queued" in result && (result as { queued?: boolean }).queued === true) {
+  // Soft success — optimistic update already applied; outbox will flush on reconnect.
+  return;
+}
+// Else: normal action-result shape (e.g. { ok, data } or { ok, error }); existing handling.
+```
+
+Encapsulate that check as a tiny helper if it improves readability (`function isQueued(r: unknown): r is { queued: true }`), but do not export it — keep it local to each file or factor into a single helper inside `lib/realtime/outbox.ts` only if necessary. **Do not** add a new export from `outbox.ts` if it would force editing the public API; inline the check.
+
+**Tests (`tests/unit/outbox-wiring.test.tsx`):**
+
+This is a new test file that proves the wrappers are in place. It does NOT need to render the components in full — it can mock the server actions and verify that the wrapped path runs.
+
+For each of the four call sites:
+- Mock the corresponding server action to track invocation.
+- Mock `useBoardStore.getState()` so `connection: 'offline'` is set.
+- Trigger the wrapped call (the easiest way: import the wrapped constant indirectly via the component, OR factor each `wrappedXxx` into a small adjacent module so the test can import it directly — your call. If you choose the adjacent-module factoring, that's allowed; add `lib/realtime/wrapped-actions.ts` to owns).
+- Assert: the underlying action was NOT called; `enqueueOutbox` WAS called with the right `actionId` and `args`.
+- Then flip connection to `'connected'` and assert the underlying action IS called.
+
+Even with `describe.skip` (vitest deferred to Epic 15), this is the codified proof that wrapping happened.
+
+**Definition of done:**
+- All four mutation call sites route through `withOutbox` with the correct `OutboxActionId`.
+- `queued: true` is treated as soft success at each call site (no false-positive error toast or rollback).
+- The Outbox banner will actually render when offline-then-mutate happens.
+- `tests/unit/outbox-wiring.test.tsx` exists, follows the repo's `describe.skip` + `@ts-expect-error vitest` pattern, and asserts the wrapping at each site.
+- `pnpm typecheck` clean.
+
+**Escalation triggers:**
+- If a call site's surrounding logic relies on the server action's return shape in a way that's incompatible with `{ queued: true }` (e.g. immediately reads `result.data` without checking `ok`), stop and surface — the discriminator approach may need a per-site adaptation.
+- If `withOutbox`'s generic return type fails to narrow correctly inside one of the components (TypeScript inference around discriminated unions), surface and propose a `lib/realtime/outbox.ts` helper export (`isQueuedResult`) as a one-line addition; do not silently widen with `any`.
+- If `BulkActionBar.tsx`'s call at line 388 is actually inside an unusual structure (e.g. multiple sequential mutations), surface; the goal is one wrap per server-action call.
+
+---
+
+## Open questions for the user
+
+None. All three slices are scoped from concrete code-level gaps with unambiguous fixes per the epic doc DoD.
+

--- a/docs/conversion-plan/_dispatch/epic-08.md
+++ b/docs/conversion-plan/_dispatch/epic-08.md
@@ -1,0 +1,914 @@
+# Epic 08 Dispatch — Realtime & Presence
+
+## Preconditions
+
+- Branched from `main` at commit `6112e2d` (Epic 07 merged). Epic branch: `epic/08-realtime-presence`.
+- Depends on (all merged): Epic 02 (schema + Realtime publication), Epic 04 (RLS), Epic 05 (workspaces/boards + board header), Epic 06 (groups/tasks/table + Zustand board store), Epic 07 (column system + cell registry).
+- Env: existing `NEXT_PUBLIC_SUPABASE_URL` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` are sufficient. No new env vars in this epic.
+- Verified present (read by orchestrator before plan freeze):
+  - `/Volumes/SSD1T/DEV WORK/donezo/stores/board-store.ts` — Zustand store with `persist` middleware, `partialize` for `collapsedByBoard` + `columnPrefsByBoard`, and idempotent `applyXxxUpsert/Delete` methods all keyed on `updated_at`. This is the extension point for S1.
+  - `/Volumes/SSD1T/DEV WORK/donezo/components/board/BoardHeaderClient.tsx` — single edit site for the topbar (S3+S4).
+  - `/Volumes/SSD1T/DEV WORK/donezo/components/board/table/BoardTable.tsx` (mount/hydrate logic around line 242–266) — single mount site for the realtime hook + outbox flush (S5).
+  - `/Volumes/SSD1T/DEV WORK/donezo/components/cells/TableCell.tsx` — integration point for cursor hover/focus emit (S6).
+  - `/Volumes/SSD1T/DEV WORK/donezo/supabase/migrations/20260506224930_initial_schema.sql` — defines `public.cell` (lines 204–235), `public.comment` (lines 243–258), and the reference trigger pattern `task_board_id_consistency` (lines 398–408). S0 mirrors that pattern.
+  - `/Volumes/SSD1T/DEV WORK/donezo/app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions.ts` — `setCellValue` and `bulkSetCellValue`; S0 updates these to write `board_id`.
+  - `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/` — directory exists, empty. S2 owns it.
+  - `/Volumes/SSD1T/DEV WORK/donezo/lib/supabase/client.ts` — exports `createClient()` (browser).
+  - Realtime publication is already set up at the end of the initial schema migration (lines 450–455) — `task`, `cell`, `group`, `column`, `comment`, `notification` are already members of `supabase_realtime`. S0 does not re-add.
+
+## Stage 1 — Parallel slices
+
+---
+
+### Slice S0: Realtime denormalization migration + cell/comment `board_id`
+
+**Owner:** epic-executor (sonnet)
+**Branch:** `epic/08-realtime-presence/s0-realtime-denorm`
+**Owns (write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/supabase/migrations/<NEW_TIMESTAMP>_realtime_denormalization.sql` (new file; pick a timestamp later than `20260511075330`)
+- `/Volumes/SSD1T/DEV WORK/donezo/app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions.ts` (update `setCellValue` + `bulkSetCellValue` upsert payloads to include `board_id`)
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/supabase/types.ts` (regenerated)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/cell-actions.test.ts` (extend existing tests to assert `board_id` is set on upsert)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/policies/board_id_consistency.spec.sql` (new pgTAP test for the new triggers)
+
+**Reads (no write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/supabase/migrations/20260506224930_initial_schema.sql` — pattern reference at lines 398–408 (`task_board_id_consistency`).
+- `/Volumes/SSD1T/DEV WORK/donezo/app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions.ts` — to add `board_id: col.board_id` to upsert payloads.
+
+**Forbidden:** Any file outside the list above. No changes to RLS policy files (existing policies remain valid since they reason via `task → group → board`; the new `board_id` is defense-in-depth only). Do not touch the `comment` server actions — Epic 09 owns writes; this slice just adds the column so 09 has it ready.
+
+**Depends on:** none (Stage 1 starts here).
+
+**Spec (self-contained — executor will not see this conversation):**
+
+1. **Migration SQL.** Create `supabase/migrations/<TIMESTAMP>_realtime_denormalization.sql`. Use a timestamp greater than `20260511075330` (e.g. `20260512000000`). Contents, in this order:
+   ```sql
+   -- Epic 08 — denormalize board_id onto cell + comment so Realtime postgres_changes
+   -- can filter board_id=eq.<id>. Defense-in-depth consistency triggers mirror the
+   -- existing task_board_id_consistency pattern.
+
+   -- 1. Add columns (nullable initially so backfill can run before NOT NULL is enforced).
+   alter table public.cell    add column board_id uuid references public.board(id) on delete cascade;
+   alter table public.comment add column board_id uuid references public.board(id) on delete cascade;
+
+   -- 2. Backfill from task.board_id (task already carries it, kept in sync by task_board_id_consistency).
+   update public.cell    set board_id = (select board_id from public.task where id = cell.task_id);
+   update public.comment set board_id = (select board_id from public.task where id = comment.task_id);
+
+   -- 3. Enforce NOT NULL post-backfill.
+   alter table public.cell    alter column board_id set not null;
+   alter table public.comment alter column board_id set not null;
+
+   -- 4. Indexes for the filter and for FK joins.
+   create index cell_board_idx    on public.cell(board_id);
+   create index comment_board_idx on public.comment(board_id);
+
+   -- 5. Defense-in-depth consistency triggers — mirror task_board_id_consistency
+   --    pattern from the initial schema migration (lines 398–408). These derive
+   --    board_id from the parent task on insert/update, so even a buggy server
+   --    action that forgets to set board_id cannot break the invariant.
+   create or replace function public.cell_board_id_consistency()
+   returns trigger language plpgsql as $$
+   begin
+     new.board_id = (select board_id from public.task where id = new.task_id);
+     return new;
+   end $$;
+
+   create trigger cell_board_id_consistency
+     before insert or update of task_id on public.cell
+     for each row execute function public.cell_board_id_consistency();
+
+   create or replace function public.comment_board_id_consistency()
+   returns trigger language plpgsql as $$
+   begin
+     new.board_id = (select board_id from public.task where id = new.task_id);
+     return new;
+   end $$;
+
+   create trigger comment_board_id_consistency
+     before insert or update of task_id on public.comment
+     for each row execute function public.comment_board_id_consistency();
+   ```
+   Note that the publication entries for `cell` and `comment` are already in the initial migration (lines 451, 454) — do not re-add them.
+
+2. **Update `setCellValue` and `bulkSetCellValue` in `cells/actions.ts`** to include `board_id: col.board_id` in the upsert payload. The trigger will overwrite it on the server, but writing it from the action is faster and self-documenting. Apply to both the single upsert path and the bulk payload mapping. Do not change any other behavior in the file. Keep the `@ts-expect-error` comments intact.
+
+3. **Regenerate types** by running `pnpm supabase gen types typescript --local > lib/supabase/types.ts` (or the equivalent project script — check `/Volumes/SSD1T/DEV WORK/donezo/package.json` for the canonical name; typically `pnpm db:types`). Commit the regenerated `types.ts`. `cell.board_id` and `comment.board_id` must appear as non-null in the generated `Row` types.
+
+4. **Tests.**
+   - Extend `tests/unit/cell-actions.test.ts`: assert that the upsert payload passed to `supabase.from('cell').upsert(...)` contains `board_id` matching the column's board, in both `setCellValue` and `bulkSetCellValue` mocked-supabase tests.
+   - Create `tests/policies/board_id_consistency.spec.sql` (pgTAP). Two assertions: (a) inserting a `cell` with the wrong `board_id` results in the row landing with the task's `board_id` (trigger overwrites); (b) same for `comment`. Follow the style of existing pgTAP tests under `/Volumes/SSD1T/DEV WORK/donezo/tests/policies/`.
+
+**Tests:**
+- `pnpm test -- cell-actions` passes with extended assertions.
+- `supabase test db` (pgTAP runner used by the repo) passes the new consistency spec.
+- `pnpm tsc --noEmit` is clean against the regenerated types.
+
+**Definition of done:**
+- Migration applies cleanly on a fresh DB and on an existing DB with data.
+- `cell.board_id` and `comment.board_id` are `not null` and indexed.
+- Triggers overwrite incorrect `board_id` values on insert/update of `task_id`.
+- `setCellValue` + `bulkSetCellValue` set `board_id` in the upsert payload.
+- Generated types reflect the new columns; no other code in the repo fails typecheck against the regen.
+- New pgTAP test passes locally.
+
+**Escalation triggers:**
+- If `pnpm tsc --noEmit` surfaces breakage in code outside this slice's file scope after type regen — stop, return a `needs-direction` report listing the failing files. Do not edit them.
+- If existing RLS policies reference `cell` or `comment` in a way that the new `board_id` should be used (rather than the current `task → group → board` join), surface as a question.
+- If the migration timestamp conflicts with another stage's migration, surface as a coordination issue.
+
+---
+
+### Slice S1: Board store — connection, presence, cursors, typing, outbox slices
+
+**Owner:** epic-executor (sonnet)
+**Branch:** `epic/08-realtime-presence/s1-store-extensions`
+**Owns (write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/stores/board-store.ts` (extend in place)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/board-store.test.ts` (extend with new state-shape tests; the existing file is yours to add to, not to overwrite)
+- `/Volumes/SSD1T/DEV WORK/donezo/stores/types/realtime.ts` (new — type definitions for presence/cursor/typing/outbox payloads)
+
+**Reads (no write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/supabase/types.ts` — for `Database` row types.
+
+**Forbidden:** Any other store file (`sidebar-store.ts`), any component, any hook. Do not import from `@/lib/realtime` — that's S2's territory and the import would create a dependency cycle at module load.
+
+**Depends on:** none (parallel-safe — only edits store and store-local types).
+
+**Spec:**
+
+You are extending the existing Zustand `useBoardStore` to hold the additional client state Realtime needs: connection status, presence membership, cursor positions, typing-indicator state (keyed by context), and an offline outbox. All new state must be transient with the **exception of `outbox`**, which is the second persisted slice (in addition to the existing `collapsedByBoard` and `columnPrefsByBoard`).
+
+1. **Create `stores/types/realtime.ts`** with these exact exported types:
+   ```ts
+   export type ConnectionStatus = "connected" | "reconnecting" | "offline";
+
+   // viewing.type is "board" today; "task" is forward-compat for Epic 09 (task drawer).
+   // task_id is only set when type === "task".
+   export type PresenceViewing =
+     | { type: "board" }
+     | { type: "task"; task_id: string };
+
+   export type PresenceEntry = {
+     user_id: string;
+     online_at: number; // epoch ms
+     viewing: PresenceViewing;
+   };
+
+   // Supabase Realtime presence state: keyed by presence key (we use userId),
+   // each value is an array of one entry per active tab/connection for that user.
+   export type PresenceState = Record<string, PresenceEntry[]>;
+
+   // Broadcast: cursor position in the table view.
+   export type CursorPayload = {
+     user_id: string;
+     task_id: string;
+     column_id: string;
+     at: number; // epoch ms — used to expire stale cursors
+   };
+
+   // Broadcast: typing indicator. `context` is opaque (e.g. `comment:<task_id>`).
+   export type TypingPayload = {
+     user_id: string;
+     context: string;
+     at: number; // epoch ms — used to expire after 5s
+   };
+
+   // ----- Outbox -----
+   // Queueable actions: upsert-style only. Inserts/deletes do NOT queue and must
+   // error immediately when offline (handled by S8's wrapper, not by the store).
+   export type OutboxActionId =
+     | "setCellValue"
+     | "bulkSetCellValue"
+     | "renameGroup"
+     | "renameTask"
+     | "updateTaskFields"; // any future task-field upsert
+
+   export type OutboxEntry = {
+     id: string; // uuid v4 generated client-side ONLY for de-duplication of the outbox itself; NOT a DB id
+     actionId: OutboxActionId;
+     args: unknown[]; // serialized server-action args; server action validates via Zod on flush
+     optimisticUpdatedAt: number; // epoch ms, used purely for ordering/visibility
+     enqueuedAt: number; // epoch ms
+   };
+   ```
+
+2. **Extend `BoardState`** in `stores/board-store.ts` with these new fields and actions. Place them in a logical group with a banner comment "// Epic 08 — Realtime + outbox state". Do NOT alter any existing field, action, or method.
+
+   New transient fields (added to `transientInitial`):
+   ```ts
+   connection: "connected" as ConnectionStatus,
+   presence: {} as PresenceState,
+   cursors: new Map<string, CursorPayload>(), // key: user_id; one cursor per user
+   typingByContext: new Map<string, TypingPayload[]>(), // key: context string
+   ```
+
+   New persisted field (NOT in `transientInitial`; alongside `collapsedByBoard`/`columnPrefsByBoard`):
+   ```ts
+   outbox: [] as OutboxEntry[],
+   ```
+
+   New actions on the state interface:
+   ```ts
+   // connection
+   setConnectionStatus: (status: ConnectionStatus) => void;
+
+   // presence
+   setPresence: (state: PresenceState) => void;
+
+   // cursors
+   setCursor: (payload: CursorPayload) => void;
+   clearCursor: (userId: string) => void;
+   pruneExpiredCursors: (now: number, ttlMs: number) => void; // remove cursors where now - at > ttlMs
+
+   // typing
+   setTyping: (payload: TypingPayload) => void;
+   pruneExpiredTyping: (now: number, ttlMs: number) => void; // typically ttlMs = 5000
+
+   // outbox
+   enqueueOutbox: (entry: Omit<OutboxEntry, "id" | "enqueuedAt">) => void; // generates id + enqueuedAt
+   dequeueOutbox: (entryId: string) => void;
+   clearOutbox: () => void;
+   ```
+
+3. **Multi-tab dedupe for presence display.** `setPresence` stores the raw state as-given by Supabase. Add a derived selector helper to the same file (exported, not on the store interface):
+   ```ts
+   /** Returns the deduped list of user_ids currently present (one entry per user, regardless of tab count). */
+   export function selectPresentUserIds(state: BoardState): string[] {
+     return Object.keys(state.presence).filter((uid) => (state.presence[uid] ?? []).length > 0);
+   }
+
+   /** Returns deduped user_ids currently viewing a specific task (any tab). */
+   export function selectUsersViewingTask(state: BoardState, taskId: string): string[] {
+     const out: string[] = [];
+     for (const [uid, entries] of Object.entries(state.presence)) {
+       if (entries.some((e) => e.viewing.type === "task" && e.viewing.task_id === taskId)) {
+         out.push(uid);
+       }
+     }
+     return out;
+   }
+   ```
+   In Epic 08 we only use `selectPresentUserIds`. `selectUsersViewingTask` is exported but unused — Epic 09 will consume it. Add a `// epic 09 will consume` comment above it.
+
+4. **Persistence extension.** The existing `persist` config uses `partialize` to persist `collapsedByBoard` and `columnPrefsByBoard`. Extend `partialize` to also persist `outbox`. Bump nothing — the storage key stays `donezo:board-collapsed:v1` (preserve existing localStorage entries; new field is additive). Document this in a comment above `partialize`:
+   ```ts
+   // Persisted slices: collapsedByBoard, columnPrefsByBoard, outbox.
+   // Storage key name is historical (was collapse-only); not renamed to preserve
+   // existing entries. outbox added in Epic 08 — older entries hydrate with outbox: [].
+   ```
+   In `onRehydrateStorage`, if `state` is missing `outbox` (older clients), default it to `[]`:
+   ```ts
+   if (state && !Array.isArray(state.outbox)) {
+     state.outbox = [];
+   }
+   ```
+
+5. **Outbox size cap.** localStorage has a ~5MB browser quota shared across this key. In `enqueueOutbox`, before pushing, check if the serialized JSON length of `outbox` would exceed ~4MB (4 * 1024 * 1024 chars; conservative). If so, **do not enqueue**; instead set a one-time flag `outboxOverflow: true` on the store and toast via the action wrapper (S8 owns the toast; this slice just sets the flag). Add `outboxOverflow: boolean` to transient state.
+
+6. **Reset behavior.** Extend `reset()` to preserve `outbox` in addition to the existing persisted slices. (Navigating boards must not drop a queued offline mutation.)
+
+7. **Idempotency.** None of the new actions need `updated_at`-style idempotency — they're all UI/transport state. `setPresence` overwrites wholesale (Supabase already gives the canonical state). `setCursor` overwrites per user_id. `setTyping` appends to the per-context list and de-dupes by user_id (one typing entry per user per context — newer `at` overwrites older).
+
+**Tests:**
+Extend `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/board-store.test.ts`. Add a new `describe('Epic 08 — realtime state', ...)` block:
+- `setConnectionStatus` transitions.
+- `setPresence` overwrites; `selectPresentUserIds` returns deduped keys.
+- `setCursor` upserts per user_id; `pruneExpiredCursors` removes old ones.
+- `setTyping` de-dupes per (context, user_id); `pruneExpiredTyping` clears stale.
+- `enqueueOutbox` generates `id` + `enqueuedAt`; `dequeueOutbox` removes by id; `clearOutbox` empties.
+- `enqueueOutbox` refuses to push when serialized outbox > 4MB; sets `outboxOverflow: true`. (Construct a giant args payload to exercise this.)
+- `reset()` preserves `outbox`.
+- Rehydration with no `outbox` field defaults to `[]` (mock localStorage via the existing harness in the test file).
+
+**Definition of done:**
+- All new fields and actions present and typed.
+- `partialize` includes `outbox` alongside the existing two slices.
+- `selectPresentUserIds` exported.
+- `outboxOverflow` flag set on cap breach.
+- `pnpm test -- board-store` passes; `pnpm tsc --noEmit` clean.
+
+**Escalation triggers:**
+- If the existing `persist` config's storage key is renamed by a parallel slice or a recent commit, stop and report.
+- If `selectUsersViewingTask` requires a different shape because Epic 09's drawer routing has already been spec'd to use room IDs etc. — surface as a question.
+
+---
+
+### Slice S2: `useBoardRealtime` hook + channel helpers + throttle util + reconnect refresh
+
+**Owner:** epic-executor (sonnet)
+**Branch:** `epic/08-realtime-presence/s2-realtime-hook`
+**Owns (write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/hooks/use-board-realtime.ts` (new)
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/channel.ts` (new — channel name helper + subscribe helper)
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/throttle.ts` (new — small leading+trailing throttle util)
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/types.ts` (new — re-export of payload types from `stores/types/realtime.ts` for hook consumers)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/use-board-realtime.test.ts` (new — mocked Supabase client)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/realtime-throttle.test.ts` (new)
+
+**Reads (no write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/supabase/client.ts` (uses `createClient`)
+- `/Volumes/SSD1T/DEV WORK/donezo/stores/board-store.ts` (calls store actions only; do not modify)
+- `/Volumes/SSD1T/DEV WORK/donezo/stores/types/realtime.ts` (created by S1; import types from here)
+
+**Forbidden:** Any UI component, any route, the store file. Do not write tests that depend on a real Supabase connection.
+
+**Depends on:** S1 (the hook reads/writes store fields S1 adds; the executor must wait for S1 to merge OR be unblocked by orchestrator with merge-base coordination). Mark as **sequenced after S1** if S1 hasn't landed by the time this slice starts.
+
+> Orchestrator note: S2 reads S1's symbols. Run S2 after S1 lands on the epic branch, or instruct S2's executor to rebase onto the post-S1 epic-branch tip. Do not parallelize S2 and S1.
+
+**Spec:**
+
+The hook owns the entire board-scoped Realtime lifecycle: postgres_changes for `task`/`cell`/`group`/`column`, presence for membership, and broadcast for cursors/typing. It is consumed by `BoardTable.tsx` (S5).
+
+1. **`lib/realtime/channel.ts`** — small helper module:
+   ```ts
+   export function boardChannelName(boardId: string): string {
+     return `board:${boardId}`;
+   }
+   ```
+
+2. **`lib/realtime/throttle.ts`** — leading+trailing throttle (no external deps):
+   ```ts
+   /**
+    * throttle(fn, wait) — invokes fn at most once per `wait` ms.
+    * Leading edge fires immediately; trailing edge fires the last call if any
+    * occurred during the throttle window. Returns a function with a `.cancel()`
+    * method to clear any pending trailing call.
+    */
+   export function throttle<TArgs extends unknown[]>(
+     fn: (...args: TArgs) => void,
+     wait: number,
+   ): ((...args: TArgs) => void) & { cancel: () => void };
+   ```
+   Implement with `setTimeout` + a last-args ref. Tests exercise: leading call fires synchronously; trailing call fires after `wait`; rapid calls are coalesced; `cancel()` clears pending timer.
+
+3. **`hooks/use-board-realtime.ts`** — signature:
+   ```ts
+   "use client";
+   export function useBoardRealtime(boardId: string, userId: string): void;
+   ```
+
+   Behavior — implement inside a single `useEffect` keyed on `[boardId, userId]`:
+
+   a. Create a Supabase browser client via `createClient()`.
+
+   b. Open one channel named `boardChannelName(boardId)` with config:
+   ```ts
+   { broadcast: { self: false }, presence: { key: userId } }
+   ```
+
+   c. **Postgres changes subscriptions** — one `channel.on('postgres_changes', ...)` per table, all using `filter: 'board_id=eq.<boardId>'`:
+      - `task` → on `*` event, dispatch to store: INSERT/UPDATE → `applyTaskUpsert(e.new)`, DELETE → `applyTaskDelete(e.old.id)`.
+      - `group` → INSERT/UPDATE → `applyGroupUpsert(e.new)`, DELETE → `applyGroupDelete(e.old.id)`.
+      - `column` → INSERT/UPDATE → `applyColumnUpsert(e.new)`, DELETE → `applyColumnDelete(e.old.id)`.
+      - `cell` → with `filter: 'board_id=eq.<boardId>'` (now possible after S0). INSERT/UPDATE → `applyCellUpsert(e.new)`. DELETE: no store method exists for cells; skip (cells are upserts in our model; deletion happens via column or task delete cascades, which the parent table's DELETE event covers via store cascade in `applyColumnDelete`/`applyTaskDelete`). Log a `console.warn` in dev mode if a `cell` DELETE event is received.
+      - **DO NOT subscribe to `comment` in Epic 08.** That is explicitly deferred to Epic 09. Add a comment in the hook: `// comment postgres_changes deferred to epic 09`.
+
+   d. **Presence** — `channel.on('presence', { event: 'sync' }, () => { store.setPresence(channel.presenceState() as PresenceState); })`. Also listen for `join` and `leave` events but the handler is a no-op; the `sync` event always carries the canonical state and is what we render against.
+
+   e. **Broadcast** — two subscriptions:
+      - `channel.on('broadcast', { event: 'cursor' }, ({ payload }) => store.setCursor(payload as CursorPayload))`
+      - `channel.on('broadcast', { event: 'typing' }, ({ payload }) => store.setTyping(payload as TypingPayload))`
+
+   f. **Subscribe + lifecycle.** Call `channel.subscribe(async (status) => { ... })`. Status transitions:
+      - `SUBSCRIBED`:
+        - If `previousStatus === 'reconnecting'`, call `router.refresh()` (from `useRouter` of `next/navigation`) BEFORE marking connected. This re-runs the RSC tree on `BoardPage` and rehydrates the store via `BoardTable`'s mount-time `hydrate` call. **No `revalidateTag`, no server action, no cache layer.**
+        - `store.setConnectionStatus('connected')`.
+        - `await channel.track({ user_id: userId, online_at: Date.now(), viewing: { type: 'board' } })` — note `viewing` shape per Q3 (forward-compat for Epic 09 task drawer).
+      - `TIMED_OUT` or `CHANNEL_ERROR`: `store.setConnectionStatus('reconnecting')`. Also `store.setPresence({})` so stale avatars clear.
+      - `CLOSED`: only fires on intentional unsubscribe; no action.
+   
+   Track `previousStatus` in a `useRef` so the `SUBSCRIBED` handler can detect the reconnect transition.
+
+   g. **Cleanup** — return `() => { channel.unsubscribe(); supabase.removeChannel(channel); }`.
+
+   h. **Cursor expiry sweeper.** Also start a `setInterval` (every 2s) that calls `useBoardStore.getState().pruneExpiredCursors(Date.now(), 5000)` and `pruneExpiredTyping(Date.now(), 5000)`. Clear the interval in cleanup. (Bandwidth note: the throttled emit guarantees regular refreshes for active users, so a 5s TTL is comfortable.)
+
+   i. **No imports from React Server Components.** The hook is `"use client"`. `useRouter` from `next/navigation`.
+
+4. **Window/tab note.** S2 does NOT add a visibility-state pause for subscriptions themselves — per Q5 we keep subscriptions live on hidden tabs. The emit-side pause for cursor/typing belongs to S6 and S7 respectively.
+
+**Tests:**
+Mock `@supabase/ssr` so `createClient` returns a stub channel with chainable `.on(...)`, `.subscribe(cb)`, `.track(payload)`, `.unsubscribe()`, and `presenceState()`. Use `vitest`'s fake timers. Verify:
+- All postgres_changes subscriptions are registered with `filter: 'board_id=eq.<boardId>'` and event `'*'`.
+- `cell` table subscription is registered (not skipped post-S0).
+- `comment` subscription is NOT registered.
+- On `SUBSCRIBED`, `track` is called with `{ user_id, online_at, viewing: { type: 'board' } }` and store `setConnectionStatus('connected')`.
+- On `TIMED_OUT`, store `setConnectionStatus('reconnecting')` and presence is cleared.
+- On `TIMED_OUT → SUBSCRIBED`, `router.refresh()` is called (mock `useRouter`).
+- The sweeper interval calls `pruneExpiredCursors` and `pruneExpiredTyping` every 2s.
+- Cleanup calls `channel.unsubscribe()` and `removeChannel`.
+
+Separate `realtime-throttle.test.ts`:
+- Leading call fires synchronously.
+- Repeated calls within `wait` are coalesced; last args win on trailing.
+- `cancel()` prevents trailing fire.
+
+**Definition of done:**
+- Hook compiles and is exported. Channel name uses `board:<id>` exactly (matches Supabase config naming convention used throughout the app).
+- All store dispatches are typed (no `any`).
+- Mocked test suite passes; >90% branch coverage on the hook.
+- `router.refresh()` only fires on the reconnect transition, not on the first subscribe.
+- Comment subscription verifiably absent.
+
+**Escalation triggers:**
+- If `applyTaskDelete` / `applyGroupDelete` / `applyColumnDelete` signatures from the existing store differ from "takes a string id" — stop, report. (Verified at plan time: they take `taskId: string`, `groupId: string`, `columnId: string`. Confirm before dispatching.)
+- If a `*_DELETE` postgres_changes event's `e.old` does not include `id` (Supabase publication setup affects this) — stop, report. Default expectation: `id` is the PK and is present in `old` for DELETE.
+
+---
+
+### Slice S3+S4 (merged): Topbar realtime UI — `PresencePile` + `ConnectionStatus`
+
+**Owner:** epic-executor (sonnet)
+**Branch:** `epic/08-realtime-presence/s3-topbar-presence`
+**Owns (write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/PresencePile.tsx` (new)
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/ConnectionStatus.tsx` (new)
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/OutboxBanner.tsx` (new — but only the file shell with a placeholder export; S8 will implement the body)
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/BoardHeaderClient.tsx` (single edit — add the three new components into the header layout)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/PresencePile.test.tsx` (new)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/ConnectionStatus.test.tsx` (new)
+
+**Reads (no write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/components/shared/Avatar.tsx` — `Avatar` accepts `src`, `displayName`, `email`, `size: 22 | 24 | 26 | 30 | 37.4`, `borderColor`, `className`.
+- `/Volumes/SSD1T/DEV WORK/donezo/components/shared/MemberStack.tsx` — visual reference for the avatar pile (you are NOT extending it; presence avatars need a "live" treatment per epic doc — green dot or ring).
+- `/Volumes/SSD1T/DEV WORK/donezo/stores/board-store.ts` — read connection + presence; do not modify.
+- `/Volumes/SSD1T/DEV WORK/donezo/docs/conversion-plan/design-system.md` — for tokens.
+- `/Volumes/SSD1T/DEV WORK/donezo/docs/conversion-plan/component-system.md` — for any legacy "who's here" pattern (if listed).
+
+**Forbidden:** Any other component file. Do not modify `MemberStack.tsx` or `Avatar.tsx`. Do not implement the body of `OutboxBanner.tsx` — leave it as a placeholder return-null with a `// implemented in S8` comment so S8 can fill it in without re-creating the file.
+
+**Depends on:** S1 (reads new store fields). Sequence after S1 lands.
+
+**Spec:**
+
+The board topbar needs three new pieces of UI:
+- A **PresencePile** showing avatars of users currently viewing the board (deduped per user across tabs).
+- A **ConnectionStatus** indicator that is invisible when `connected` and renders a small pill/dot+label when `reconnecting` or `offline`.
+- An **OutboxBanner** that is implemented in S8 but whose component file is created here so the header edit can be done once.
+
+1. **`PresencePile.tsx`** — props:
+   ```ts
+   interface PresencePileProps {
+     members: Array<{ id: string; displayName: string | null; email: string | null; avatarUrl: string | null }>;
+     currentUserId: string;
+     max?: number; // default 4 (matches existing MemberStack default)
+   }
+   ```
+   Behavior:
+   - Read presence: `const presentIds = useBoardStore(selectPresentUserIds)` (use the exported selector from S1).
+   - Filter out the current user from the displayed pile (`currentUserId`).
+   - Resolve each `present_id` against `members[id]`. If a present user is not in the members list (race condition: just-joined invitee), render an Avatar with `displayName=null, email=null` (fallback `?` initial).
+   - Render avatars left-to-right with `-ml-2` overlap (mirror MemberStack's visual rhythm). Use `Avatar` size `24` and `borderColor="white"` for the overlap halo.
+   - Add a small **green dot** (`bg-[color:var(--color-success)]`, 8px) absolute-positioned at the bottom-right of each avatar to indicate "live". Use the legacy "online" green from design tokens; if no `--color-success` token exists, use `bg-green-500` and add a TODO comment to map to a design token. (Check `design-system.md` for the canonical online green; the legacy SCSS has `$gradient-green` and a "viewed/online" color.)
+   - If `presentIds.length > max`, render a `+N` chip with the same shape, same overlap.
+   - Tooltip on hover: each avatar shows the member's displayName/email. Use existing tooltip pattern (Base UI / shadcn — check `components/ui/` for what's already imported elsewhere in the topbar). If no tooltip primitive is already in use, use a `title` attribute for v1 and add a TODO; do not introduce a new dependency.
+
+2. **`ConnectionStatus.tsx`** — no props. Reads `connection` from the store. Render:
+   - `connected` → `null` (invisible).
+   - `reconnecting` → small pill: yellow pulsing dot + "Reconnecting…". Tailwind: `animate-pulse bg-yellow-500`.
+   - `offline` → small pill: red dot + "You're offline. Changes will sync when you reconnect." Tailwind: `bg-red-500`.
+   - Use `role="status"` and `aria-live="polite"`.
+   - Use design-system tokens (`var(--color-warning)` / `var(--color-danger)`) if defined; else map to tailwind colors with a TODO.
+
+3. **`OutboxBanner.tsx`** — placeholder:
+   ```tsx
+   "use client";
+   // Implemented in S8. Returning null keeps the header layout stable for S3+S4 to wire.
+   export function OutboxBanner() { return null; }
+   ```
+
+4. **Edit `BoardHeaderClient.tsx`** — one edit, in one place:
+   - Add imports for `PresencePile`, `ConnectionStatus`, `OutboxBanner`.
+   - Get `currentUserId` from a new prop on `BoardHeaderClientProps`:
+     ```ts
+     interface BoardHeaderClientProps {
+       members: Member[];
+       createdByName: string | null;
+       currentUserId: string; // new — provided by BoardHeader.tsx server component
+     }
+     ```
+   - Update the BoardHeader server component (`/Volumes/SSD1T/DEV WORK/donezo/components/board/BoardHeader.tsx`) to read the current user via existing helpers (look for the pattern already used — likely `await getSessionUser()` or similar in `lib/auth/`) and pass `currentUserId` down. **This is part of this slice's owned writes** — add `components/board/BoardHeader.tsx` to your owns list at top.
+   - Render order inside the `<header>` element, immediately before the existing `MemberStack` line at `BoardHeaderClient.tsx:133`:
+     ```tsx
+     <PresencePile members={memberStackItems.map(m => ({...m}))} currentUserId={currentUserId} />
+     <ConnectionStatus />
+     <OutboxBanner />
+     ```
+   - Keep `MemberStack` as-is. The two stacks coexist for now — `MemberStack` is "board members" (durable), `PresencePile` is "live now" (transient). Add a comment above the PresencePile call: `// live presence — green-dotted avatars of users on this board right now (Epic 08)`.
+
+   **Update owns list addendum:** add `/Volumes/SSD1T/DEV WORK/donezo/components/board/BoardHeader.tsx` to the writeable file list. Forbidden expansion: do not touch the auth helper itself.
+
+**Tests:**
+- `PresencePile.test.tsx`: render with a store containing 0, 1, 3, 8 present users; verify visible avatar count = min(N, max), `+N` chip shows when overflow, current user excluded, missing-member fallback works.
+- `ConnectionStatus.test.tsx`: render with each of the three states; assert the `null`/visible-pill/visible-pill outputs, the aria-live attribute, and that the offline message string matches the spec.
+
+**Definition of done:**
+- Three new components exist and compile.
+- `BoardHeader.tsx` passes `currentUserId` down; `BoardHeaderClient.tsx` renders the three new pieces.
+- `PresencePile` reads from the store via `selectPresentUserIds`; never renders the current user; correctly resolves members; falls back gracefully on unknown presence ids.
+- `ConnectionStatus` returns `null` when connected (no DOM noise).
+- `OutboxBanner` exists as a placeholder; S8 will fill it in by editing the file body, not re-creating it.
+- Component tests pass.
+
+**Escalation triggers:**
+- If `design-system.md` has explicit tokens for `--color-success` / `--color-warning` / `--color-danger`, use them. If not, surface as a question — do NOT invent token names.
+- If the legacy `frontend/` component-system reference shows a different layout for the presence pile (e.g. it sits on a separate row, not inline), surface that and stop. The epic doc says "top-of-board: avatar pile" without further detail; an existing legacy pattern wins if one exists.
+
+---
+
+### Slice S6: Cursor broadcast — emitter hook + overlay renderer + TableCell integration
+
+**Owner:** epic-executor (sonnet)
+**Branch:** `epic/08-realtime-presence/s6-cursors`
+**Owns (write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/hooks/use-cursor-broadcast.ts` (new)
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/CursorOverlay.tsx` (new)
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/cursor-color.ts` (new — user_id → stable hex color)
+- `/Volumes/SSD1T/DEV WORK/donezo/components/cells/TableCell.tsx` (single edit — add hover/focus handlers that call the emit hook + render the overlay)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/use-cursor-broadcast.test.ts` (new)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/cursor-color.test.ts` (new)
+
+**Reads (no write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/supabase/client.ts`
+- `/Volumes/SSD1T/DEV WORK/donezo/stores/board-store.ts`
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/throttle.ts` (from S2)
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/channel.ts` (from S2)
+- `/Volumes/SSD1T/DEV WORK/donezo/components/cells/TableCell.tsx` — file is in your owns list because you edit it; do not edit any other cell file.
+
+**Forbidden:** Any cell-type implementation under `components/cells/<type>/`. Any other board component except `TableCell.tsx`. Do not modify `useBoardRealtime` (S2) — the cursor emit uses its OWN channel reference acquired the same way (one channel per board; Supabase deduplicates by channel name within a client).
+
+**Depends on:** S1, S2. Sequence after both.
+
+**Spec:**
+
+Two parts: **emit** the current user's cursor (the cell they're hovering or focusing) to other clients, and **render** other users' cursors as colored dots inside the relevant cell.
+
+1. **`lib/realtime/cursor-color.ts`** — pure function:
+   ```ts
+   /** Returns a stable hex color string for a user_id. Uses a tiny hash → HSL. */
+   export function cursorColorForUser(userId: string): string;
+   ```
+   Implementation: hash userId to a number (e.g. sum char codes mod 360), produce `hsl(<h>, 70%, 50%)`. Avoid h=0..20 (red conflicts with offline indicator) — shift the hue out of that band. Test that two distinct user_ids produce distinct hues most of the time, that the same user_id always returns the same color, and that no output is in the red band.
+
+2. **`hooks/use-cursor-broadcast.ts`** — emit-only hook (subscribing to incoming cursors is already done by `useBoardRealtime` in S2):
+   ```ts
+   "use client";
+   export function useCursorBroadcast(boardId: string, userId: string): {
+     emit: (taskId: string, columnId: string) => void;
+   };
+   ```
+   Behavior:
+   - Inside the hook, obtain the same channel reference: `supabase.channel(boardChannelName(boardId))`. Supabase's client caches channels by name; calling `.channel()` with the same name twice returns the same instance. (Confirm by reading the Supabase JS docs if uncertain; the documented behavior is "deduplicated by topic".)
+   - Wrap a throttled emitter (use `throttle` from S2, `wait = 100ms`):
+     ```ts
+     const send = throttle((taskId: string, columnId: string) => {
+       if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return; // Q5: pause emit on hidden tabs
+       channel.send({
+         type: 'broadcast',
+         event: 'cursor',
+         payload: { user_id: userId, task_id: taskId, column_id: columnId, at: Date.now() } satisfies CursorPayload,
+       });
+     }, 100);
+     ```
+   - Return `{ emit: send }`.
+   - On unmount, call `send.cancel()`. Do NOT call `removeChannel` — `useBoardRealtime` owns the lifecycle.
+
+3. **`components/board/CursorOverlay.tsx`** — renders cursor dots for a single cell:
+   ```tsx
+   interface CursorOverlayProps {
+     taskId: string;
+     columnId: string;
+   }
+   export function CursorOverlay({ taskId, columnId }: CursorOverlayProps): JSX.Element | null;
+   ```
+   Reads `cursors: Map<string, CursorPayload>` from the store; filters entries where `task_id === taskId && column_id === columnId`; for each match, renders an absolutely-positioned 8px colored dot (color from `cursorColorForUser(user_id)`) in the cell's top-right corner. If multiple users are on the same cell, stack them with a 4px horizontal offset (cap at 3 visible; render `+N` text beyond).
+   - `position: absolute; top: 2px; right: 2px; pointer-events: none; z-index: 1;`
+   - `role="presentation"` on the wrapper — these are non-interactive decorations.
+
+4. **Edit `components/cells/TableCell.tsx`**:
+   - Add `boardId` to TableCellProps. The caller (`TaskRow.tsx`) already has `boardId` via the page context — verify by checking how `boardId` flows from `BoardTable.tsx` → `TaskRow.tsx` → `TableCell`. If `TaskRow` doesn't currently have it, you may need to thread it through. **If threading `boardId` through `TaskRow.tsx` is required, that is in your owns list — add `/Volumes/SSD1T/DEV WORK/donezo/components/board/table/TaskRow.tsx`.** If `BoardTable` already passes `boardId` to `TaskRow`, just consume it.
+   - Get the current `userId`. Use the existing `useBoard` hook from `/Volumes/SSD1T/DEV WORK/donezo/hooks/use-board.ts` — verify whether it exposes the user id; if not, add it (this is acceptable scope expansion since `use-board.ts` is the natural place; if it does not currently provide a user id and adding it would touch unrelated logic, surface as a needs-direction).
+   - In `TableCellInner`, call `const { emit } = useCursorBroadcast(boardId, userId)`.
+   - On the `<button>` add `onMouseEnter={() => emit(task.id, column.id)}` and `onFocus={() => emit(task.id, column.id)}`.
+   - Wrap the button (or place a sibling inside the wrapper div) with `<CursorOverlay taskId={task.id} columnId={column.id} />`. The overlay needs a positioned parent — wrap the existing button in a `<div className="relative">` if it isn't already positioned. Inspect the current cell structure and preserve all existing className behavior.
+
+5. **Performance.** Throttle is 100ms; that caps each user at 10 emits/s. Pruning runs in S2's interval. No additional rAF needed.
+
+**Tests:**
+- `cursor-color.test.ts`: stable per user_id; out of red hue band.
+- `use-cursor-broadcast.test.ts`: mock supabase channel; assert `send` is throttled (10 rapid calls within 100ms result in ≤2 channel.send calls — leading + trailing); assert payload shape; assert visibility-hidden suppresses emit; assert unmount calls `cancel`.
+
+**Definition of done:**
+- Cursor emit hook compiles; throttled correctly; respects visibility.
+- CursorOverlay renders zero-DOM when no cursors match.
+- TableCell hover/focus triggers emit without regressing the edit-mode flow (clicking still opens the editor; the emit fires on enter/focus, not on click).
+- Color helper produces stable, non-red hues.
+- Unit tests pass.
+
+**Escalation triggers:**
+- If `useBoard` does not expose the current user's id and adding it would require touching unrelated context-provider plumbing — stop, report.
+- If Supabase JS client does NOT deduplicate channels by topic (it should, but if the version pinned in the repo behaves differently), stop and report. The fallback is to pass the channel handle down from S5's mount site as a context — that's a different architecture and needs orchestrator approval.
+
+---
+
+### Slice S7: Typing broadcast plumbing (hooks only — no UI consumer)
+
+**Owner:** epic-executor (sonnet)
+**Branch:** `epic/08-realtime-presence/s7-typing`
+**Owns (write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/hooks/use-typing-broadcast.ts` (new — emitter)
+- `/Volumes/SSD1T/DEV WORK/donezo/hooks/use-typing-indicator.ts` (new — reader)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/use-typing-broadcast.test.ts` (new)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/use-typing-indicator.test.ts` (new)
+
+**Reads (no write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/stores/board-store.ts`
+- `/Volumes/SSD1T/DEV WORK/donezo/stores/types/realtime.ts`
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/channel.ts`
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/throttle.ts`
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/supabase/client.ts`
+
+**Forbidden:** Any component file. There is NO UI consumer in Epic 08 — Epic 09 will consume these hooks when the comment input lands. Do not import these hooks anywhere outside their own tests.
+
+**Depends on:** S1, S2. Sequence after both.
+
+**Spec:**
+
+Ship the plumbing for typing indicators as a library, ready for Epic 09. Two hooks: emitter and reader.
+
+1. **`hooks/use-typing-broadcast.ts`**:
+   ```ts
+   "use client";
+   /**
+    * Emits a typing event for a given context (e.g. `comment:<task_id>`).
+    * Throttled to one emit per 2000ms. Pauses on hidden tabs.
+    *
+    * Returns an `emit()` function the caller invokes on every keystroke;
+    * the throttle handles the rest. No automatic "stopped typing" event —
+    * the reader hook expires entries after 5s of silence.
+    *
+    * Epic 08 ships this as plumbing only. Epic 09's CommentComposer is the
+    * first caller.
+    */
+   export function useTypingBroadcast(args: {
+     boardId: string;
+     userId: string;
+     context: string; // e.g. `comment:<task_id>`
+   }): { emit: () => void };
+   ```
+   Implementation mirrors `useCursorBroadcast`: get the same-named channel, throttle to 2000ms, payload `{ user_id, context, at: Date.now() } satisfies TypingPayload`, gate on `document.visibilityState === 'visible'`. Cancel on unmount.
+
+2. **`hooks/use-typing-indicator.ts`**:
+   ```ts
+   "use client";
+   /**
+    * Returns the list of OTHER users currently typing in the given context.
+    * Self is filtered out. Stale entries (> 5s) are excluded via the store's
+    * pruneExpiredTyping sweeper (run by useBoardRealtime).
+    */
+   export function useTypingIndicator(args: {
+     userId: string;     // current user, to filter self
+     context: string;
+   }): Array<{ user_id: string; at: number }>;
+   ```
+   Implementation: subscribe to `typingByContext` via `useBoardStore`, look up the context list, filter out `user_id === userId`, return.
+
+3. **Tests.**
+   - `use-typing-broadcast.test.ts`: throttled at 2000ms; visibility-hidden suppresses; channel.send payload shape correct; unmount cancels.
+   - `use-typing-indicator.test.ts`: with store seeded to `typingByContext: { 'comment:t1': [{u1, at1}, {u2, at2}] }` and `userId: 'u1'`, hook returns only `[{u2, at2}]`.
+
+**Definition of done:**
+- Both hooks compile, are exported from their own files, and have no callers in production code yet.
+- Tests cover throttle, visibility-pause, self-filter, context-isolation.
+- Hooks documented with a JSDoc note: "First consumer lands in Epic 09 (CommentComposer)."
+
+**Escalation triggers:**
+- None expected. If the channel deduplication concern from S6 surfaces here, same escalation path.
+
+---
+
+### Slice S8: Offline write queue — outbox flush logic, action wrapper, banner UI
+
+**Owner:** epic-executor (sonnet)
+**Branch:** `epic/08-realtime-presence/s8-outbox`
+**Owns (write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/outbox.ts` (new — `withOutbox(actionId, action)` wrapper + `flushOutbox()` function + `isOnline()` helper)
+- `/Volumes/SSD1T/DEV WORK/donezo/lib/realtime/outbox-registry.ts` (new — maps `OutboxActionId` → the server-action function to call on flush)
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/OutboxBanner.tsx` (REPLACE the placeholder body created by S3+S4; do not re-create the file)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/outbox.test.ts` (new)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/OutboxBanner.test.tsx` (new)
+
+**Reads (no write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions.ts` — `setCellValue`, `bulkSetCellValue`.
+- `/Volumes/SSD1T/DEV WORK/donezo/app/(app)/w/[workspaceSlug]/b/[boardId]/groups/actions.ts` — `renameGroup`.
+- `/Volumes/SSD1T/DEV WORK/donezo/app/(app)/w/[workspaceSlug]/b/[boardId]/tasks/actions.ts` — `renameTask` (find the exact export name; if it's `updateTask` or similar, use that and update the `OutboxActionId` union in S1's `stores/types/realtime.ts`).
+- `/Volumes/SSD1T/DEV WORK/donezo/stores/board-store.ts` — read `outbox`, `connection`, call `enqueueOutbox` / `dequeueOutbox` / `clearOutbox`.
+
+**Forbidden:** Server action files themselves — do not modify them. The wrapper is a client-side decoration applied at the call site. Do not change the existing connection-status logic (S2 owns it). Do not write to any new server action.
+
+**Depends on:** S1 (store + types), S2 (uses `connection` field from store). Sequence after both. **S8 does NOT need S3+S4 to merge** — only the `OutboxBanner.tsx` file must already exist (S3+S4 creates the placeholder). If S3+S4 hasn't merged yet, coordinate with the orchestrator.
+
+**Spec:**
+
+This slice ships the offline write queue per the locked-in decisions: upsert-style mutations only, localStorage persistence (already wired by S1's `partialize`), last-write-wins on flush, yellow banner UI.
+
+1. **`lib/realtime/outbox.ts`**:
+   ```ts
+   "use client";
+
+   /** Returns navigator.onLine; SSR-safe (true on server). */
+   export function isOnline(): boolean;
+
+   /**
+    * Wrap an upsert-style server action so that, if offline, the call is
+    * enqueued in the store's outbox instead of throwing the network error.
+    * Inserts and deletes must NOT use this wrapper — they should error
+    * immediately when offline (their callers toast the error).
+    *
+    * @param actionId  the OutboxActionId tag used to replay on flush
+    * @param action    the server action function (the actual reference, not a string)
+    */
+   export function withOutbox<TArgs extends unknown[], TReturn>(
+     actionId: OutboxActionId,
+     action: (...args: TArgs) => Promise<TReturn>,
+   ): (...args: TArgs) => Promise<TReturn | { queued: true }>;
+
+   /**
+    * Replays all queued entries in submission order.
+    * Called by S5's mount-time effect on connection 'connected' transition
+    * and on window 'online' events.
+    *
+    * On per-entry failure: toasts the error and DROPS the entry (no infinite retry).
+    * Returns the count of successfully flushed entries and the count of dropped entries.
+    */
+   export async function flushOutbox(): Promise<{ flushed: number; dropped: number }>;
+   ```
+
+   Implementation notes:
+   - `withOutbox` checks `useBoardStore.getState().connection`. If `'offline'` OR `!isOnline()`, call `enqueueOutbox({ actionId, args, optimisticUpdatedAt: Date.now() })` and return `{ queued: true }` immediately. Caller's UI can treat `queued: true` as a soft success (the optimistic update already applied via the store's `applyXxxUpsert` happens BEFORE the wrapped action is invoked — that's the caller's responsibility, not the wrapper's).
+   - If online, invoke the action; on network error (`TypeError: Failed to fetch` heuristic, or any error whose `message` matches `/network|fetch/i`), enqueue + return `{ queued: true }`. On any OTHER error (validation, auth), re-throw — those are real errors and the caller's existing toast logic handles them.
+   - On overflow (`outboxOverflow: true` is set by the store), toast: "Offline queue is full — recent changes won't sync. Reconnect to flush." Do not enqueue. Return a thrown error so the caller's catch path runs.
+
+2. **`lib/realtime/outbox-registry.ts`** — the registry that `flushOutbox` consults:
+   ```ts
+   import { setCellValue, bulkSetCellValue } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions";
+   import { renameGroup } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/groups/actions";
+   // ... and renameTask / updateTaskFields if those exist with those names
+
+   export const outboxRegistry: Record<OutboxActionId, (...args: unknown[]) => Promise<unknown>> = {
+     setCellValue: setCellValue as (...a: unknown[]) => Promise<unknown>,
+     bulkSetCellValue: bulkSetCellValue as (...a: unknown[]) => Promise<unknown>,
+     renameGroup: renameGroup as (...a: unknown[]) => Promise<unknown>,
+     renameTask: renameTask as (...a: unknown[]) => Promise<unknown>,
+     updateTaskFields: /* if exists */ as (...a: unknown[]) => Promise<unknown>,
+   };
+   ```
+   If `renameTask` / `updateTaskFields` don't exist under those exact names, **read** the actions directory and adapt the `OutboxActionId` union accordingly. Coordinate with S1 to keep the union in sync — if you need to amend the union after S1 merged, do it in this slice's diff (touching `stores/types/realtime.ts` is therefore allowed for this narrow purpose; add it to your owns).
+
+3. **`components/board/OutboxBanner.tsx`** — replace the placeholder body:
+   ```tsx
+   "use client";
+   import { useBoardStore } from "@/stores/board-store";
+   export function OutboxBanner() {
+     const count = useBoardStore((s) => s.outbox.length);
+     if (count === 0) return null;
+     return (
+       <div role="status" aria-live="polite"
+            className="inline-flex items-center gap-2 px-3 py-1 text-xs rounded
+                       bg-yellow-100 text-yellow-900 border border-yellow-300">
+         <span className="inline-block w-2 h-2 rounded-full bg-yellow-500 animate-pulse" />
+         Syncing {count} pending change{count === 1 ? '' : 's'}…
+       </div>
+     );
+   }
+   ```
+   Use design-system warning tokens if defined (`var(--color-warning-bg)`, etc.); otherwise tailwind colors with a TODO comment, matching the same handling rule from S3+S4.
+
+4. **Flush trigger.** The actual mount-time call to `flushOutbox()` (on window `online` event + on store `connection` transitioning to `connected`) is owned by **S5**. S8 only exports `flushOutbox`. Document this clearly in a comment at the top of `outbox.ts`:
+   ```ts
+   // Flush is triggered by hooks/board mount in S5; this module only exports the function.
+   ```
+
+**Tests:**
+- `outbox.test.ts`:
+  - `withOutbox` enqueues when offline (mock `useBoardStore` connection = 'offline').
+  - `withOutbox` enqueues when online but action throws a network error.
+  - `withOutbox` re-throws when action throws a validation error.
+  - `withOutbox` refuses to enqueue when `outboxOverflow` is true; throws.
+  - `flushOutbox` replays entries in submission order (set up 3 entries; mock registry actions to record call order; assert).
+  - `flushOutbox` drops an entry whose action throws; toasts; continues with the next.
+  - `flushOutbox` returns `{ flushed, dropped }` counts.
+- `OutboxBanner.test.tsx`: hidden when count=0; visible with correct text for count=1, count=5; correct aria-live.
+
+**Definition of done:**
+- `withOutbox` is callable as a wrapper around any of the supported actions.
+- Banner renders correctly based solely on `outbox.length`.
+- `flushOutbox` is exported but not invoked from this slice's files.
+- localStorage persistence proven by an integration-style test that writes to the store, reads `localStorage['donezo:board-collapsed:v1']`, and confirms the outbox blob is present.
+- No insert/delete server action is wrapped (verify: the registry contains only the documented action ids).
+
+**Escalation triggers:**
+- If the actions directory exposes function names that differ from the spec's `OutboxActionId` union (e.g. no `updateTaskFields`), stop, list the actual exports, and propose the corrected union as a delta — do not silently rename.
+- If you find that any existing call site of the wrapped actions already throws toasts on network failure that would interfere with the `withOutbox` swallow, surface that and propose either (a) leaving those sites un-wrapped, or (b) updating those sites within S5's slice (not yours).
+
+---
+
+## Stage 2 — Sequential
+
+### Slice S5: Mount realtime hook + outbox flush trigger + e2e + CONTRIBUTING note
+
+**Owner:** epic-executor (sonnet)
+**Branch:** `epic/08-realtime-presence/s5-mount-and-e2e`
+**Owns (write):**
+- `/Volumes/SSD1T/DEV WORK/donezo/components/board/table/BoardTable.tsx` (single edit — mount `useBoardRealtime` + `flushOutbox` trigger)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/e2e/08-realtime.spec.ts` (new — Playwright 2-client tests)
+- `/Volumes/SSD1T/DEV WORK/donezo/CONTRIBUTING.md` (append a section; create if missing)
+- `/Volumes/SSD1T/DEV WORK/donezo/tests/unit/BoardTable-realtime-mount.test.tsx` (new — verify the hook is invoked on mount with correct args; not a full BoardTable re-test)
+
+**Reads (no write):**
+- All previous slice outputs.
+- `/Volumes/SSD1T/DEV WORK/donezo/app/(app)/w/[workspaceSlug]/b/[boardId]/page.tsx` — to understand how `boardId` is passed to BoardTable. If `BoardTable` needs to receive `userId` and currently does not, pass it as a new prop from the page; **`page.tsx` is added to your owns list** for this single edit.
+
+**Forbidden:** Any other component or hook. The implementations of useBoardRealtime, hooks, components, store, and migration are frozen by the time this slice runs.
+
+**Depends on:** ALL of S0, S1, S2, S3+S4, S6, S7, S8. **Sequential — must run only after all Stage 1 slices land on the epic branch.**
+
+**Spec:**
+
+1. **Mount `useBoardRealtime`** in `BoardTable.tsx`. The existing component already runs a hydration effect (line ~252–266). Add a sibling effect or call the hook at the top of the component:
+   ```ts
+   useBoardRealtime(boardId, userId); // userId is a new prop
+   ```
+   `userId` becomes a new `BoardTableProps` field. Plumb from `page.tsx` (RSC) — read the user via the existing `lib/auth` helper (look for the pattern used by other pages like `account/page.tsx` or the BoardHeader).
+
+2. **Mount flush trigger.** Inside `BoardTable.tsx`, add a `useEffect` that:
+   - Listens for `window` `online` event → `flushOutbox()`.
+   - Subscribes to the store's `connection` field → on transition to `'connected'`, `flushOutbox()`.
+   - Cleans up on unmount.
+   ```ts
+   useEffect(() => {
+     const onOnline = () => { void flushOutbox(); };
+     window.addEventListener('online', onOnline);
+     const unsub = useBoardStore.subscribe((s) => s.connection, (curr, prev) => {
+       if (prev !== 'connected' && curr === 'connected') void flushOutbox();
+     });
+     return () => { window.removeEventListener('online', onOnline); unsub(); };
+   }, []);
+   ```
+   Note: `useBoardStore.subscribe` with a selector is the Zustand v4 API. Confirm the version pinned in `package.json` supports it; if not, fall back to the v5 `subscribeWithSelector` middleware or a manual `subscribe((state) => ...)` with prev/curr tracking inside the effect.
+
+3. **Playwright e2e** at `tests/e2e/08-realtime.spec.ts`. Use the existing test harness pattern from `tests/e2e/06-board-table.spec.ts`. Spawn two browser contexts (two users; reuse the seed fixtures). Tests:
+   - **Live cell edit.** Both users open board B. User A edits cell (t1, c1) to value V. Within 1500ms, User B's DOM reflects V.
+   - **Live task add.** User A adds a task. User B sees it appear within 1500ms.
+   - **Presence pile.** Both users on the board → both see 1 avatar each (the other user) in `PresencePile`. User A navigates away → User B's pile shows 0.
+   - **Connection status.** Force-offline User A's context via `context.setOffline(true)`. The yellow "Reconnecting…" or red "offline" pill appears in A's topbar within 5s. Restore online → pill disappears within 10s, and a `router.refresh()` re-fetch occurs (verify by editing a cell on User B while A is offline; on A's reconnect, A sees the new value).
+   - **Cursor dot.** User A hovers cell (t1, c1). Within 500ms, User B sees a colored dot in cell (t1, c1).
+
+   Keep tests deterministic — use `expect.poll` for the time-bounded assertions; do not use raw `setTimeout`.
+
+4. **CONTRIBUTING.md note.** Add a section "Realtime & writes":
+   > Donezo's writes go through server actions only. Realtime is read-only on the client — postgres_changes events feed the Zustand store via idempotent `applyXxxUpsert` methods, gated on `updated_at`. Never write to the database directly from the client. Presence and broadcast (cursors, typing) are non-persistent advisory state; the server does not trust them.
+
+5. **Unit test.** `BoardTable-realtime-mount.test.tsx` mocks `useBoardRealtime` and `flushOutbox`, renders `BoardTable`, and asserts:
+   - `useBoardRealtime` is called with `(boardId, userId)`.
+   - `flushOutbox` is called when the mocked store transitions to `connected`.
+   - Listeners are removed on unmount.
+
+**Tests:**
+- `pnpm test:e2e -- 08-realtime` passes locally with the local Supabase stack running (`pnpm supabase start` + `pnpm dev`).
+- `pnpm test -- BoardTable-realtime-mount` passes.
+
+**Definition of done:**
+- The board page mounts both realtime + outbox flush wiring exactly once.
+- All Playwright assertions pass.
+- CONTRIBUTING.md contains the realtime invariant.
+
+**Escalation triggers:**
+- If the Zustand store version does not support `subscribe(selector, listener)` — surface and ask whether to install `subscribeWithSelector` middleware or roll a manual diff.
+- If Playwright's `context.setOffline(true)` does not suspend Supabase Realtime in the way the spec expects (Realtime uses websockets; offline blocks them), the connection-status test might be flaky — surface and propose using `context.route` to block the websocket URL pattern instead.
+- If `userId` plumbing through `page.tsx` requires changes to the auth helper, stop and surface.
+
+---
+
+## Followups (post-merge)
+
+These are explicitly not blockers for declaring Epic 08 done; record for the orchestrator's backlog:
+
+- Tooltip primitive: if S3+S4 fell back to `title` attribute, introduce a proper tooltip (Base UI `@base-ui/react/popover` or shadcn `Tooltip`) in a separate followup.
+- Design-system tokens: if `--color-success/warning/danger` were missing, propose additions to `design-system.md` and a token migration follow-up.
+- Per-channel auth tokens (Q11) — deferred to a future security epic.
+- Long-text concurrent editing (Tiptap collaborative) — deferred indefinitely; document the LWW limitation in user-facing docs.
+- Mobile data: disable cursor broadcast on small viewports (epic 14 mobile pass).
+- Cell DELETE postgres_changes event handling — log-only today; if observed in practice, add a `applyCellDelete(taskId, columnId)` to the store.
+
+## Risk notes
+
+- **Channel deduplication assumption.** S6 and S7 rely on Supabase's JS client returning the same channel object for repeated `createClient().channel('board:<id>')` calls. This is documented behavior but if the pinned version regresses, S2 would need to expose its channel handle via a React context, which is an architectural change. Escalation paths in S6/S7 cover this.
+- **Outbox replay reordering.** Last-write-wins per cell + strict submission-order replay means a queued cell edit will land AFTER any concurrent online edits during the offline window — i.e. the offline user's stale value clobbers the newer value. This is acceptable per the locked decision; document it in CONTRIBUTING.md as part of S5's note.
+- **Stage 1 ordering nuance.** Although S0/S1/S2/S3+S4/S6/S7/S8 are described as "Stage 1 parallel," S2 reads S1, and S6/S7/S8 read S1 and S2. True parallelism is **only** S0 with the rest. The orchestrator should run S0 in true parallel; S1 starts immediately; once S1 lands, S2 starts; once S2 lands, S6/S7/S8 may run in parallel. S3+S4 needs S1 only. This is closer to a wave schedule than a single stage — execute in waves: **Wave A: S0 + S1**, **Wave B: S2 + S3+S4** (both depend only on S1), **Wave C: S6 + S7 + S8** (depend on S2), **Wave D: S5**.
+- **Type regen failures.** S0's type regen could surface latent issues in other files. The escalation trigger is in S0; expect a possible mini-followup to clean up downstream typecheck errors.
+- **pgTAP runner availability.** If `supabase test db` is not wired in this repo's `package.json`, S0's pgTAP test may need a runner script first. Check `package.json` scripts before assuming.
+- **Cursor color & color-blindness.** Hash-to-HSL doesn't guarantee distinguishable colors for users with color vision deficiency. Acceptable for an internal tool; surface as a future a11y task.
+- **Comment subscription deferral (Q8).** S2 explicitly skips the `comment` postgres_changes listener. Epic 09 must add it; flag this in the Epic 09 dispatch plan.

--- a/hooks/use-board-realtime.ts
+++ b/hooks/use-board-realtime.ts
@@ -1,0 +1,227 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { boardChannelName } from "@/lib/realtime/channel";
+import type { CursorPayload, PresenceState, TypingPayload } from "@/lib/realtime/types";
+import { createClient } from "@/lib/supabase/client";
+import { useBoardStore } from "@/stores/board-store";
+
+/**
+ * useBoardRealtime — owns the entire board-scoped Realtime lifecycle.
+ *
+ * Subscribes to:
+ *  - postgres_changes for task, group, column, cell (all filtered by board_id)
+ *  - presence for membership (sync event drives setPresence)
+ *  - broadcast for cursor and typing events
+ *
+ * Lifecycle:
+ *  - On SUBSCRIBED after reconnecting: calls router.refresh() to rehydrate RSC
+ *    tree, then marks connected and tracks the user's presence.
+ *  - On TIMED_OUT / CHANNEL_ERROR: marks reconnecting and clears stale presence.
+ *  - Cleans up channel and sweeper interval on unmount or [boardId, userId] change.
+ *
+ * comment postgres_changes deferred to epic 09
+ */
+export function useBoardRealtime(boardId: string, userId: string): void {
+  const router = useRouter();
+  // Track previous subscribe status to detect the reconnect transition
+  const previousStatusRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    // Open one channel for the entire board
+    const channel = supabase.channel(boardChannelName(boardId), {
+      config: {
+        broadcast: { self: false },
+        presence: { key: userId },
+      },
+    });
+
+    // ------------------------------------------------------------------
+    // Postgres changes — task
+    // ------------------------------------------------------------------
+    channel.on(
+      "postgres_changes",
+      {
+        event: "*",
+        schema: "public",
+        table: "task",
+        filter: `board_id=eq.${boardId}`,
+      },
+      (e: { eventType: string; new: Record<string, unknown>; old: Record<string, unknown> }) => {
+        const store = useBoardStore.getState();
+        if (e.eventType === "INSERT" || e.eventType === "UPDATE") {
+          store.applyTaskUpsert(e.new as Parameters<typeof store.applyTaskUpsert>[0]);
+        } else if (e.eventType === "DELETE") {
+          const id = (e.old as { id?: string }).id;
+          if (id) {
+            store.applyTaskDelete(id);
+          }
+        }
+      },
+    );
+
+    // ------------------------------------------------------------------
+    // Postgres changes — group
+    // ------------------------------------------------------------------
+    channel.on(
+      "postgres_changes",
+      {
+        event: "*",
+        schema: "public",
+        table: "group",
+        filter: `board_id=eq.${boardId}`,
+      },
+      (e: { eventType: string; new: Record<string, unknown>; old: Record<string, unknown> }) => {
+        const store = useBoardStore.getState();
+        if (e.eventType === "INSERT" || e.eventType === "UPDATE") {
+          store.applyGroupUpsert(e.new as Parameters<typeof store.applyGroupUpsert>[0]);
+        } else if (e.eventType === "DELETE") {
+          const id = (e.old as { id?: string }).id;
+          if (id) {
+            store.applyGroupDelete(id);
+          }
+        }
+      },
+    );
+
+    // ------------------------------------------------------------------
+    // Postgres changes — column
+    // ------------------------------------------------------------------
+    channel.on(
+      "postgres_changes",
+      {
+        event: "*",
+        schema: "public",
+        table: "column",
+        filter: `board_id=eq.${boardId}`,
+      },
+      (e: { eventType: string; new: Record<string, unknown>; old: Record<string, unknown> }) => {
+        const store = useBoardStore.getState();
+        if (e.eventType === "INSERT" || e.eventType === "UPDATE") {
+          store.applyColumnUpsert(e.new as Parameters<typeof store.applyColumnUpsert>[0]);
+        } else if (e.eventType === "DELETE") {
+          const id = (e.old as { id?: string }).id;
+          if (id) {
+            store.applyColumnDelete(id);
+          }
+        }
+      },
+    );
+
+    // ------------------------------------------------------------------
+    // Postgres changes — cell
+    // cell DELETEs: no store method exists for direct cell deletion.
+    // Cells are removed client-side as a cascade from applyColumnDelete /
+    // applyTaskDelete when their parent is deleted. Log a warn in dev if
+    // a bare cell DELETE arrives (unexpected in our model).
+    // ------------------------------------------------------------------
+    channel.on(
+      "postgres_changes",
+      {
+        event: "*",
+        schema: "public",
+        table: "cell",
+        filter: `board_id=eq.${boardId}`,
+      },
+      (e: { eventType: string; new: Record<string, unknown>; old: Record<string, unknown> }) => {
+        const store = useBoardStore.getState();
+        if (e.eventType === "INSERT" || e.eventType === "UPDATE") {
+          store.applyCellUpsert(e.new as Parameters<typeof store.applyCellUpsert>[0]);
+        } else if (e.eventType === "DELETE") {
+          // No store method exists for direct cell deletion — cells are removed
+          // client-side via cascade in applyColumnDelete / applyTaskDelete.
+          if (process.env.NODE_ENV !== "production") {
+            // biome-ignore lint/suspicious/noConsole: dev-only diagnostic for unexpected cell DELETE
+            console.warn(
+              "[useBoardRealtime] Received unexpected cell DELETE event. " + "Cell id:",
+              (e.old as { id?: string }).id,
+              "— No store method; relies on parent cascade.",
+            );
+          }
+        }
+      },
+    );
+
+    // comment postgres_changes deferred to epic 09
+
+    // ------------------------------------------------------------------
+    // Presence — sync is the canonical event; join/leave are no-ops
+    // ------------------------------------------------------------------
+    channel.on("presence", { event: "sync" }, () => {
+      useBoardStore.getState().setPresence(channel.presenceState() as PresenceState);
+    });
+
+    channel.on("presence", { event: "join" }, () => {
+      // no-op: sync event always carries the canonical state
+    });
+
+    channel.on("presence", { event: "leave" }, () => {
+      // no-op: sync event always carries the canonical state
+    });
+
+    // ------------------------------------------------------------------
+    // Broadcast — cursor and typing events from other clients
+    // ------------------------------------------------------------------
+    channel.on("broadcast", { event: "cursor" }, ({ payload }: { payload: unknown }) => {
+      useBoardStore.getState().setCursor(payload as CursorPayload);
+    });
+
+    channel.on("broadcast", { event: "typing" }, ({ payload }: { payload: unknown }) => {
+      useBoardStore.getState().setTyping(payload as TypingPayload);
+    });
+
+    // ------------------------------------------------------------------
+    // Subscribe + lifecycle
+    // ------------------------------------------------------------------
+    channel.subscribe(async (status: string) => {
+      const store = useBoardStore.getState();
+
+      if (status === "SUBSCRIBED") {
+        // If recovering from a disconnect, refresh the RSC tree to rehydrate
+        // server data before marking connected. This re-runs BoardPage's RSC
+        // and triggers BoardTable's mount-time hydrate() call.
+        // No revalidateTag, no server action, no cache layer.
+        if (previousStatusRef.current === "reconnecting") {
+          router.refresh();
+        }
+
+        previousStatusRef.current = "connected";
+        store.setConnectionStatus("connected");
+
+        // Track this user's presence on the board
+        await channel.track({
+          user_id: userId,
+          online_at: Date.now(),
+          viewing: { type: "board" },
+        });
+      } else if (status === "TIMED_OUT" || status === "CHANNEL_ERROR") {
+        previousStatusRef.current = "reconnecting";
+        store.setConnectionStatus("reconnecting");
+        // Clear stale presence so stale avatars don't linger
+        store.setPresence({});
+      }
+      // CLOSED fires on intentional unsubscribe only — no action needed
+    });
+
+    // ------------------------------------------------------------------
+    // Cursor + typing expiry sweeper (runs every 2s)
+    // ------------------------------------------------------------------
+    const sweepInterval = setInterval(() => {
+      const store = useBoardStore.getState();
+      store.pruneExpiredCursors(Date.now(), 5000);
+      store.pruneExpiredTyping(Date.now(), 5000);
+    }, 2000);
+
+    // ------------------------------------------------------------------
+    // Cleanup
+    // ------------------------------------------------------------------
+    return () => {
+      clearInterval(sweepInterval);
+      channel.unsubscribe();
+      supabase.removeChannel(channel);
+    };
+  }, [boardId, userId, router]);
+}

--- a/hooks/use-cursor-broadcast.ts
+++ b/hooks/use-cursor-broadcast.ts
@@ -1,0 +1,66 @@
+"use client";
+
+/**
+ * use-cursor-broadcast.ts — emit-only hook for broadcasting the current user's
+ * cursor position (hovered/focused cell) to other board participants.
+ *
+ * Subscribing to incoming cursors is handled by useBoardRealtime (S2).
+ * This hook only emits.
+ *
+ * Channel: acquires `supabase.channel(boardChannelName(boardId))`. Supabase's
+ * client caches channels by topic; calling .channel() with the same name as
+ * useBoardRealtime returns the same instance — no duplicate subscriptions.
+ *
+ * On unmount: calls send.cancel() to clear any pending trailing throttle call.
+ * Does NOT call removeChannel — useBoardRealtime owns the lifecycle.
+ */
+
+import { useEffect, useRef } from "react";
+import { boardChannelName } from "@/lib/realtime/channel";
+import { throttle } from "@/lib/realtime/throttle";
+import { createClient } from "@/lib/supabase/client";
+import type { CursorPayload } from "@/stores/types/realtime";
+
+export function useCursorBroadcast(
+  boardId: string,
+  userId: string,
+): { emit: (taskId: string, columnId: string) => void } {
+  // Keep a stable ref to the throttled emitter across renders.
+  const emitRef = useRef<((taskId: string, columnId: string) => void) & { cancel: () => void }>(
+    null,
+  );
+
+  useEffect(() => {
+    const supabase = createClient();
+    // Supabase deduplicates channels by topic — same channel as useBoardRealtime.
+    const channel = supabase.channel(boardChannelName(boardId));
+
+    const send = throttle((taskId: string, columnId: string) => {
+      // Q5: pause emit on hidden tabs — broadcasts are not meaningful on inactive tabs.
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") return;
+      channel.send({
+        type: "broadcast",
+        event: "cursor",
+        payload: {
+          user_id: userId,
+          task_id: taskId,
+          column_id: columnId,
+          at: Date.now(),
+        } satisfies CursorPayload,
+      });
+    }, 100);
+
+    emitRef.current = send;
+
+    return () => {
+      send.cancel();
+      emitRef.current = null;
+    };
+  }, [boardId, userId]);
+
+  const emit = (taskId: string, columnId: string): void => {
+    emitRef.current?.(taskId, columnId);
+  };
+
+  return { emit };
+}

--- a/hooks/use-typing-broadcast.ts
+++ b/hooks/use-typing-broadcast.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { boardChannelName } from "@/lib/realtime/channel";
+import { throttle } from "@/lib/realtime/throttle";
+import type { TypingPayload } from "@/lib/realtime/types";
+import { createClient } from "@/lib/supabase/client";
+
+/**
+ * Emits a typing event for a given context (e.g. `comment:<task_id>`).
+ * Throttled to one emit per 2000ms. Pauses on hidden tabs.
+ *
+ * Returns an `emit()` function the caller invokes on every keystroke;
+ * the throttle handles the rest. No automatic "stopped typing" event —
+ * the reader hook expires entries after 5s of silence.
+ *
+ * Acquires the same-named `board:<boardId>` channel that useBoardRealtime
+ * already holds; Supabase deduplicates same-named channels within a client.
+ *
+ * First consumer lands in Epic 09 (CommentComposer).
+ */
+export function useTypingBroadcast(args: {
+  boardId: string;
+  userId: string;
+  context: string; // e.g. `comment:<task_id>`
+}): { emit: () => void } {
+  const { boardId, userId, context } = args;
+
+  // Keep a stable ref to the throttled send function so it can be cancelled on unmount.
+  const throttledRef = useRef<(((...a: unknown[]) => void) & { cancel: () => void }) | null>(null);
+
+  useEffect(() => {
+    const supabase = createClient();
+    // Acquires the same-named channel as useBoardRealtime — Supabase deduplicates
+    // same-named channels within a single browser client instance.
+    const channel = supabase.channel(boardChannelName(boardId), {
+      config: { broadcast: { self: false } },
+    });
+
+    const sendPayload = () => {
+      // Visibility gate: do not emit when the tab is hidden
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") {
+        return;
+      }
+      const payload: TypingPayload = {
+        user_id: userId,
+        context,
+        at: Date.now(),
+      } satisfies TypingPayload;
+
+      channel.send({
+        type: "broadcast",
+        event: "typing",
+        payload,
+      });
+    };
+
+    const throttledSend = throttle(sendPayload, 2000);
+    throttledRef.current = throttledSend;
+
+    // Subscribe the channel (Supabase dedup means this is a no-op if already open)
+    channel.subscribe();
+
+    return () => {
+      throttledRef.current?.cancel();
+      throttledRef.current = null;
+      channel.unsubscribe();
+      supabase.removeChannel(channel);
+    };
+  }, [boardId, userId, context]);
+
+  const emit = useCallback(() => {
+    throttledRef.current?.();
+  }, []);
+
+  return { emit };
+}

--- a/hooks/use-typing-broadcast.ts
+++ b/hooks/use-typing-broadcast.ts
@@ -33,9 +33,7 @@ export function useTypingBroadcast(args: {
     const supabase = createClient();
     // Acquires the same-named channel as useBoardRealtime — Supabase deduplicates
     // same-named channels within a single browser client instance.
-    const channel = supabase.channel(boardChannelName(boardId), {
-      config: { broadcast: { self: false } },
-    });
+    const channel = supabase.channel(boardChannelName(boardId));
 
     const sendPayload = () => {
       // Visibility gate: do not emit when the tab is hidden
@@ -58,14 +56,10 @@ export function useTypingBroadcast(args: {
     const throttledSend = throttle(sendPayload, 2000);
     throttledRef.current = throttledSend;
 
-    // Subscribe the channel (Supabase dedup means this is a no-op if already open)
-    channel.subscribe();
-
     return () => {
+      // useBoardRealtime owns channel lifecycle; we only cancel pending sends here.
       throttledRef.current?.cancel();
       throttledRef.current = null;
-      channel.unsubscribe();
-      supabase.removeChannel(channel);
     };
   }, [boardId, userId, context]);
 

--- a/hooks/use-typing-indicator.ts
+++ b/hooks/use-typing-indicator.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useBoardStore } from "@/stores/board-store";
+
+/**
+ * Returns the list of OTHER users currently typing in the given context.
+ * Self is filtered out. Stale entries (> 5s) are excluded via the store's
+ * pruneExpiredTyping sweeper (run by useBoardRealtime).
+ *
+ * Reads from `typingByContext` in the board store, which is populated by
+ * useBoardRealtime's broadcast listener for the "typing" event.
+ *
+ * First consumer lands in Epic 09 (CommentComposer).
+ */
+export function useTypingIndicator(args: {
+  userId: string; // current user, to filter self
+  context: string;
+}): Array<{ user_id: string; at: number }> {
+  const { userId, context } = args;
+
+  const entries = useBoardStore((state) => state.typingByContext.get(context) ?? []);
+
+  // Filter out the current user so they never see their own typing indicator
+  return entries.filter((e) => e.user_id !== userId);
+}

--- a/lib/board-context.tsx
+++ b/lib/board-context.tsx
@@ -14,23 +14,29 @@ export type BoardContextValue = {
   };
   role: Role;
   isStarred: boolean;
+  /** Current authenticated user's id — used by cursor broadcast (Epic 08 S6). */
+  userId: string;
 };
 
 export const BoardContext = createContext<BoardContextValue | null>(null);
 
-/** Provides board identity, role, and star state to the subtree. */
+/** Provides board identity, role, star state, and current user id to the subtree. */
 export function BoardProvider({
   board,
   role,
   isStarred,
+  userId,
   children,
 }: {
   board: BoardContextValue["board"];
   role: Role;
   isStarred: boolean;
+  userId: string;
   children: ReactNode;
 }) {
   return (
-    <BoardContext.Provider value={{ board, role, isStarred }}>{children}</BoardContext.Provider>
+    <BoardContext.Provider value={{ board, role, isStarred, userId }}>
+      {children}
+    </BoardContext.Provider>
   );
 }

--- a/lib/realtime/channel.ts
+++ b/lib/realtime/channel.ts
@@ -1,0 +1,13 @@
+/**
+ * Channel name helpers for Supabase Realtime.
+ * All board-scoped channels use the `board:<boardId>` convention.
+ */
+
+/**
+ * Returns the canonical Realtime channel name for a board.
+ * Format: `board:<boardId>` — matches the Supabase config naming convention
+ * used throughout the app.
+ */
+export function boardChannelName(boardId: string): string {
+  return `board:${boardId}`;
+}

--- a/lib/realtime/cursor-color.ts
+++ b/lib/realtime/cursor-color.ts
@@ -1,0 +1,39 @@
+/**
+ * cursor-color.ts — stable, deterministic color assignment for cursor overlays.
+ *
+ * Maps a user_id string to a unique HSL color. The hue is derived from a
+ * simple character-code hash, then shifted out of the red band (h ∈ [0, 20])
+ * to avoid visual conflict with the offline indicator (which uses red).
+ */
+
+/**
+ * Returns a stable HSL color string for a given user_id.
+ * The same user_id always returns the same color.
+ * Hues in [0, 20] (red band) are shifted forward to [21, ...].
+ */
+export function cursorColorForUser(userId: string): string {
+  // Simple hash: sum of (char code * position weight) mod 360
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash + userId.charCodeAt(i) * (i + 1)) % 360;
+  }
+
+  // Ensure hash is non-negative
+  hash = ((hash % 360) + 360) % 360;
+
+  // Shift the red band [0, 20] → [21, 41] to keep red distinct for offline UI.
+  // This maps hues linearly: values in 0..20 become 21..41, and values >= 21
+  // are left untouched. We scale the remaining 340 degrees into [21, 360].
+  const RED_BAND_END = 20;
+  const SHIFT = RED_BAND_END + 1; // 21
+
+  let hue: number;
+  if (hash <= RED_BAND_END) {
+    // Map 0..20 → 21..41 (one-to-one shift)
+    hue = hash + SHIFT;
+  } else {
+    hue = hash;
+  }
+
+  return `hsl(${hue}, 70%, 50%)`;
+}

--- a/lib/realtime/outbox-registry.ts
+++ b/lib/realtime/outbox-registry.ts
@@ -1,0 +1,29 @@
+"use client";
+
+/**
+ * Maps OutboxActionId → the server-action function to invoke on flush.
+ *
+ * Only upsert-style actions are registered here. Inserts and deletes are
+ * intentionally absent — they must error immediately when offline.
+ *
+ * Note on updateTaskFields: the tasks/actions.ts module does not export an
+ * `updateTaskFields` function (as of Epic 08). The OutboxActionId union in
+ * stores/types/realtime.ts was amended to remove it. If a future epic adds a
+ * general task-field upsert, it should be added here alongside the union update.
+ */
+
+import {
+  bulkSetCellValue,
+  setCellValue,
+} from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions";
+import { renameGroup } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/groups/actions";
+import { renameTask } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/tasks/actions";
+
+import type { OutboxActionId } from "@/stores/types/realtime";
+
+export const outboxRegistry: Record<OutboxActionId, (...args: unknown[]) => Promise<unknown>> = {
+  setCellValue: setCellValue as (...a: unknown[]) => Promise<unknown>,
+  bulkSetCellValue: bulkSetCellValue as (...a: unknown[]) => Promise<unknown>,
+  renameGroup: renameGroup as (...a: unknown[]) => Promise<unknown>,
+  renameTask: renameTask as (...a: unknown[]) => Promise<unknown>,
+};

--- a/lib/realtime/outbox.ts
+++ b/lib/realtime/outbox.ts
@@ -1,0 +1,127 @@
+"use client";
+
+// Flush is triggered by hooks/board mount in S5; this module only exports the function.
+
+import { toast } from "sonner";
+
+import { useBoardStore } from "@/stores/board-store";
+import type { OutboxActionId } from "@/stores/types/realtime";
+
+import { outboxRegistry } from "./outbox-registry";
+
+/**
+ * Returns navigator.onLine; SSR-safe (returns true on the server where
+ * navigator is not defined).
+ */
+export function isOnline(): boolean {
+  if (typeof navigator === "undefined") return true;
+  return navigator.onLine;
+}
+
+/**
+ * Wrap an upsert-style server action so that, if offline, the call is
+ * enqueued in the store's outbox instead of throwing the network error.
+ * Inserts and deletes must NOT use this wrapper — they should error
+ * immediately when offline (their callers toast the error).
+ *
+ * @param actionId  the OutboxActionId tag used to replay on flush
+ * @param action    the server action function (the actual reference, not a string)
+ */
+export function withOutbox<TArgs extends unknown[], TReturn>(
+  actionId: OutboxActionId,
+  action: (...args: TArgs) => Promise<TReturn>,
+): (...args: TArgs) => Promise<TReturn | { queued: true }> {
+  return async (...args: TArgs): Promise<TReturn | { queued: true }> => {
+    const store = useBoardStore.getState();
+
+    // Check for outbox overflow first
+    if (store.outboxOverflow) {
+      toast.error("Offline queue is full — recent changes won't sync. Reconnect to flush.");
+      throw new Error("Outbox overflow: cannot enqueue more entries.");
+    }
+
+    // Check if offline (store connection state OR navigator.onLine)
+    if (store.connection === "offline" || !isOnline()) {
+      store.enqueueOutbox({
+        actionId,
+        args: args as unknown[],
+        optimisticUpdatedAt: Date.now(),
+      });
+      return { queued: true };
+    }
+
+    // Online — try to invoke the action
+    try {
+      return await action(...args);
+    } catch (err: unknown) {
+      const error = err as Error;
+      const message = error?.message ?? "";
+
+      // Network-error heuristic: enqueue instead of re-throwing
+      if (/network|fetch/i.test(message)) {
+        // Re-check overflow before enqueuing after a failed network call
+        const freshStore = useBoardStore.getState();
+        if (freshStore.outboxOverflow) {
+          toast.error("Offline queue is full — recent changes won't sync. Reconnect to flush.");
+          throw new Error("Outbox overflow: cannot enqueue more entries.");
+        }
+
+        freshStore.enqueueOutbox({
+          actionId,
+          args: args as unknown[],
+          optimisticUpdatedAt: Date.now(),
+        });
+        return { queued: true };
+      }
+
+      // Any other error (validation, auth, etc.) — re-throw for the caller
+      throw err;
+    }
+  };
+}
+
+/**
+ * Replays all queued entries in submission order.
+ * Called by S5's mount-time effect on connection 'connected' transition
+ * and on window 'online' events.
+ *
+ * On per-entry failure: toasts the error and DROPS the entry (no infinite retry).
+ * Returns the count of successfully flushed entries and the count of dropped entries.
+ *
+ * Also resets outboxOverflow: false on successful flush (S1's note: S8 owns this reset).
+ */
+export async function flushOutbox(): Promise<{ flushed: number; dropped: number }> {
+  const store = useBoardStore.getState();
+  // Take a snapshot of the current outbox to replay (in submission order)
+  const entries = [...store.outbox].sort((a, b) => a.enqueuedAt - b.enqueuedAt);
+
+  let flushed = 0;
+  let dropped = 0;
+
+  for (const entry of entries) {
+    const action = outboxRegistry[entry.actionId];
+    if (!action) {
+      // Unknown action id — drop it
+      store.dequeueOutbox(entry.id);
+      dropped++;
+      toast.error(`Dropped queued action "${entry.actionId}": unknown action.`);
+      continue;
+    }
+
+    try {
+      await action(...(entry.args as unknown[]));
+      useBoardStore.getState().dequeueOutbox(entry.id);
+      flushed++;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error(`Failed to sync queued change: ${message}`);
+      useBoardStore.getState().dequeueOutbox(entry.id);
+      dropped++;
+    }
+  }
+
+  // Reset overflow flag now that flush succeeded (even partial)
+  useBoardStore.setState({ outboxOverflow: false });
+
+  return { flushed, dropped };
+}

--- a/lib/realtime/throttle.ts
+++ b/lib/realtime/throttle.ts
@@ -1,0 +1,57 @@
+/**
+ * throttle(fn, wait) — invokes fn at most once per `wait` ms.
+ * Leading edge fires immediately; trailing edge fires the last call if any
+ * occurred during the throttle window. Returns a function with a `.cancel()`
+ * method to clear any pending trailing call.
+ */
+export function throttle<TArgs extends unknown[]>(
+  fn: (...args: TArgs) => void,
+  wait: number,
+): ((...args: TArgs) => void) & { cancel: () => void } {
+  let lastCallTime: number | null = null;
+  let trailingTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastArgs: TArgs | null = null;
+
+  function cancel(): void {
+    if (trailingTimer !== null) {
+      clearTimeout(trailingTimer);
+      trailingTimer = null;
+    }
+    lastArgs = null;
+  }
+
+  function throttled(...args: TArgs): void {
+    const now = Date.now();
+
+    if (lastCallTime === null || now - lastCallTime >= wait) {
+      // Leading edge: fire immediately
+      lastCallTime = now;
+      // Cancel any pending trailing call since we're firing now
+      if (trailingTimer !== null) {
+        clearTimeout(trailingTimer);
+        trailingTimer = null;
+      }
+      fn(...args);
+      lastArgs = null;
+    } else {
+      // Within the throttle window: schedule a trailing call
+      lastArgs = args;
+      if (trailingTimer === null) {
+        const remaining = wait - (now - lastCallTime);
+        trailingTimer = setTimeout(() => {
+          trailingTimer = null;
+          lastCallTime = Date.now();
+          if (lastArgs !== null) {
+            const argsToCall = lastArgs;
+            lastArgs = null;
+            fn(...argsToCall);
+          }
+        }, remaining);
+      }
+    }
+  }
+
+  throttled.cancel = cancel;
+
+  return throttled;
+}

--- a/lib/realtime/types.ts
+++ b/lib/realtime/types.ts
@@ -1,0 +1,12 @@
+/**
+ * Re-exports of payload types from the board store for hook consumers.
+ * Centralizing here avoids direct store imports from non-store modules.
+ */
+export type {
+  ConnectionStatus,
+  CursorPayload,
+  PresenceEntry,
+  PresenceState,
+  PresenceViewing,
+  TypingPayload,
+} from "@/stores/types/realtime";

--- a/lib/realtime/wrapped-actions.ts
+++ b/lib/realtime/wrapped-actions.ts
@@ -1,0 +1,34 @@
+"use client";
+
+/**
+ * Module-level wrapped server actions for the outbox queue.
+ *
+ * Each constant is created once (not on every render) so the returned function
+ * captures the underlying server-action reference at module load time.
+ *
+ * Only upsert-style actions are wrapped here — inserts and deletes must error
+ * immediately when offline (per outbox contract in lib/realtime/outbox.ts).
+ *
+ * Factored into this module so call-site components can import a stable
+ * reference and tests can verify the wrapping without rendering components.
+ */
+
+import {
+  bulkSetCellValue,
+  setCellValue,
+} from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions";
+import { renameGroup } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/groups/actions";
+import { renameTask } from "@/app/(app)/w/[workspaceSlug]/b/[boardId]/tasks/actions";
+import { withOutbox } from "@/lib/realtime/outbox";
+
+/** setCellValue wrapped in the outbox — enqueues when offline. */
+export const wrappedSetCellValue = withOutbox("setCellValue", setCellValue);
+
+/** renameTask wrapped in the outbox — enqueues when offline. */
+export const wrappedRenameTask = withOutbox("renameTask", renameTask);
+
+/** renameGroup wrapped in the outbox — enqueues when offline. */
+export const wrappedRenameGroup = withOutbox("renameGroup", renameGroup);
+
+/** bulkSetCellValue wrapped in the outbox — enqueues when offline. */
+export const wrappedBulkSetCellValue = withOutbox("bulkSetCellValue", bulkSetCellValue);

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -207,6 +207,7 @@ export type Database = {
       }
       cell: {
         Row: {
+          board_id: string
           boolean_value: boolean | null
           column_id: string
           created_at: string
@@ -221,6 +222,7 @@ export type Database = {
           updated_by: string | null
         }
         Insert: {
+          board_id: string
           boolean_value?: boolean | null
           column_id: string
           created_at?: string
@@ -235,6 +237,7 @@ export type Database = {
           updated_by?: string | null
         }
         Update: {
+          board_id?: string
           boolean_value?: boolean | null
           column_id?: string
           created_at?: string
@@ -249,6 +252,13 @@ export type Database = {
           updated_by?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "cell_board_id_fkey"
+            columns: ["board_id"]
+            isOneToOne: false
+            referencedRelation: "board"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "cell_column_id_fkey"
             columns: ["column_id"]
@@ -319,6 +329,7 @@ export type Database = {
       comment: {
         Row: {
           author_id: string | null
+          board_id: string
           body: Json
           body_text: string
           created_at: string
@@ -328,6 +339,7 @@ export type Database = {
         }
         Insert: {
           author_id?: string | null
+          board_id: string
           body: Json
           body_text?: string
           created_at?: string
@@ -337,6 +349,7 @@ export type Database = {
         }
         Update: {
           author_id?: string | null
+          board_id?: string
           body?: Json
           body_text?: string
           created_at?: string
@@ -345,6 +358,13 @@ export type Database = {
           updated_at?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "comment_board_id_fkey"
+            columns: ["board_id"]
+            isOneToOne: false
+            referencedRelation: "board"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "comment_task_id_fkey"
             columns: ["task_id"]

--- a/stores/board-store.ts
+++ b/stores/board-store.ts
@@ -4,6 +4,13 @@ import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
 import type { Database } from "@/lib/supabase/types";
+import type {
+  ConnectionStatus,
+  CursorPayload,
+  OutboxEntry,
+  PresenceState,
+  TypingPayload,
+} from "@/stores/types/realtime";
 
 type Group = Database["public"]["Tables"]["group"]["Row"];
 type Task = Database["public"]["Tables"]["task"]["Row"];
@@ -11,7 +18,7 @@ type Cell = Database["public"]["Tables"]["cell"]["Row"];
 type Column = Database["public"]["Tables"]["column"]["Row"];
 type Label = Database["public"]["Tables"]["label"]["Row"];
 
-type BoardState = {
+export type BoardState = {
   boardId: string | null;
   groups: Group[];
   tasks: Task[];
@@ -76,6 +83,37 @@ type BoardState = {
   setDraggingTask: (taskId: string | null) => void;
   setDraggingGroup: (groupId: string | null) => void;
   setEditingTask: (taskId: string | null) => void;
+
+  // Epic 08 — Realtime + outbox state
+  // Transient fields
+  connection: ConnectionStatus;
+  presence: PresenceState;
+  cursors: Map<string, CursorPayload>; // key: user_id; one cursor per user
+  typingByContext: Map<string, TypingPayload[]>; // key: context string
+  outboxOverflow: boolean;
+
+  // Persisted field
+  outbox: OutboxEntry[];
+
+  // connection
+  setConnectionStatus: (status: ConnectionStatus) => void;
+
+  // presence
+  setPresence: (state: PresenceState) => void;
+
+  // cursors
+  setCursor: (payload: CursorPayload) => void;
+  clearCursor: (userId: string) => void;
+  pruneExpiredCursors: (now: number, ttlMs: number) => void; // remove cursors where now - at > ttlMs
+
+  // typing
+  setTyping: (payload: TypingPayload) => void;
+  pruneExpiredTyping: (now: number, ttlMs: number) => void; // typically ttlMs = 5000
+
+  // outbox
+  enqueueOutbox: (entry: Omit<OutboxEntry, "id" | "enqueuedAt">) => void; // generates id + enqueuedAt
+  dequeueOutbox: (entryId: string) => void;
+  clearOutbox: () => void;
 };
 
 /** SSR-safe noop storage — used when `window` is not available. */
@@ -101,6 +139,13 @@ const transientInitial = {
   collapsedGroupIds: new Set<string>(),
   editingTaskId: null,
   tempIdMap: new Map<string, string>(),
+
+  // Epic 08 — Realtime + outbox state (transient portion)
+  connection: "connected" as ConnectionStatus,
+  presence: {} as PresenceState,
+  cursors: new Map<string, CursorPayload>(), // key: user_id; one cursor per user
+  typingByContext: new Map<string, TypingPayload[]>(), // key: context string
+  outboxOverflow: false,
 };
 
 export const useBoardStore = create<BoardState>()(
@@ -112,6 +157,8 @@ export const useBoardStore = create<BoardState>()(
         string,
         Record<string, { width?: number; hidden?: boolean }>
       >,
+      // Epic 08 — persisted outbox (additive; older entries hydrate with outbox: [])
+      outbox: [] as OutboxEntry[],
 
       // ------------------------------------------------------------------
       // hydrate — called once on mount with server-fetched data.
@@ -162,15 +209,17 @@ export const useBoardStore = create<BoardState>()(
       },
 
       // ------------------------------------------------------------------
-      // reset — clears transient state but PRESERVES collapsedByBoard
-      // AND columnPrefsByBoard (both are persisted slices)
+      // reset — clears transient state but PRESERVES collapsedByBoard,
+      // columnPrefsByBoard, AND outbox (all persisted slices).
+      // Navigating boards must not drop a queued offline mutation.
       // ------------------------------------------------------------------
       reset() {
-        const { collapsedByBoard, columnPrefsByBoard } = get();
+        const { collapsedByBoard, columnPrefsByBoard, outbox } = get();
         set({
           ...transientInitial,
           collapsedByBoard,
           columnPrefsByBoard,
+          outbox,
         });
       },
 
@@ -546,22 +595,162 @@ export const useBoardStore = create<BoardState>()(
       setEditingTask(taskId) {
         set({ editingTaskId: taskId });
       },
+
+      // ================================================================
+      // Epic 08 — Realtime + outbox state
+      // ================================================================
+
+      // ------------------------------------------------------------------
+      // setConnectionStatus — updates the connection status field.
+      // ------------------------------------------------------------------
+      setConnectionStatus(status) {
+        set({ connection: status });
+      },
+
+      // ------------------------------------------------------------------
+      // setPresence — overwrites the entire presence state wholesale.
+      // Supabase already gives the canonical snapshot; no merge needed.
+      // ------------------------------------------------------------------
+      setPresence(state) {
+        set({ presence: state });
+      },
+
+      // ------------------------------------------------------------------
+      // setCursor — upserts the cursor for a given user_id (one cursor
+      // per user; overwrites any existing position for that user).
+      // ------------------------------------------------------------------
+      setCursor(payload) {
+        const { cursors } = get();
+        const next = new Map(cursors);
+        next.set(payload.user_id, payload);
+        set({ cursors: next });
+      },
+
+      // ------------------------------------------------------------------
+      // clearCursor — removes the cursor entry for a given user_id.
+      // ------------------------------------------------------------------
+      clearCursor(userId) {
+        const { cursors } = get();
+        const next = new Map(cursors);
+        next.delete(userId);
+        set({ cursors: next });
+      },
+
+      // ------------------------------------------------------------------
+      // pruneExpiredCursors — removes cursors where now - at > ttlMs.
+      // Called periodically by the hook to garbage-collect stale cursors.
+      // ------------------------------------------------------------------
+      pruneExpiredCursors(now, ttlMs) {
+        const { cursors } = get();
+        const next = new Map(cursors);
+        for (const [userId, cursor] of next) {
+          if (now - cursor.at > ttlMs) {
+            next.delete(userId);
+          }
+        }
+        set({ cursors: next });
+      },
+
+      // ------------------------------------------------------------------
+      // setTyping — appends or updates a typing entry for (context, user_id).
+      // De-dupes by user_id: newer `at` overwrites older for same user.
+      // ------------------------------------------------------------------
+      setTyping(payload) {
+        const { typingByContext } = get();
+        const existing = typingByContext.get(payload.context) ?? [];
+
+        // De-dupe: replace existing entry for this user_id if present
+        const withoutUser = existing.filter((e) => e.user_id !== payload.user_id);
+        const next = new Map(typingByContext);
+        next.set(payload.context, [...withoutUser, payload]);
+        set({ typingByContext: next });
+      },
+
+      // ------------------------------------------------------------------
+      // pruneExpiredTyping — removes typing entries where now - at > ttlMs
+      // (typically ttlMs = 5000). Cleans up empty context keys.
+      // ------------------------------------------------------------------
+      pruneExpiredTyping(now, ttlMs) {
+        const { typingByContext } = get();
+        const next = new Map(typingByContext);
+        for (const [context, entries] of next) {
+          const fresh = entries.filter((e) => now - e.at <= ttlMs);
+          if (fresh.length === 0) {
+            next.delete(context);
+          } else {
+            next.set(context, fresh);
+          }
+        }
+        set({ typingByContext: next });
+      },
+
+      // ------------------------------------------------------------------
+      // enqueueOutbox — generates id + enqueuedAt and pushes an entry.
+      // 4MB serialized size cap: if exceeded, sets outboxOverflow = true
+      // and does NOT enqueue (S8 owns the toast; this slice sets the flag).
+      // ------------------------------------------------------------------
+      enqueueOutbox(entry) {
+        const { outbox } = get();
+
+        // Check serialized size before pushing (4MB conservative cap)
+        const OUTBOX_SIZE_CAP = 4 * 1024 * 1024; // 4MB in chars
+        const currentSize = JSON.stringify(outbox).length;
+        if (currentSize >= OUTBOX_SIZE_CAP) {
+          set({ outboxOverflow: true });
+          return;
+        }
+
+        const newEntry: OutboxEntry = {
+          ...entry,
+          id: crypto.randomUUID(),
+          enqueuedAt: Date.now(),
+        };
+
+        // Also guard after adding the entry
+        const candidate = [...outbox, newEntry];
+        if (JSON.stringify(candidate).length > OUTBOX_SIZE_CAP) {
+          set({ outboxOverflow: true });
+          return;
+        }
+
+        set({ outbox: candidate });
+      },
+
+      // ------------------------------------------------------------------
+      // dequeueOutbox — removes the entry with the given id.
+      // ------------------------------------------------------------------
+      dequeueOutbox(entryId) {
+        const { outbox } = get();
+        set({ outbox: outbox.filter((e) => e.id !== entryId) });
+      },
+
+      // ------------------------------------------------------------------
+      // clearOutbox — empties the entire outbox (e.g. after successful flush).
+      // ------------------------------------------------------------------
+      clearOutbox() {
+        set({ outbox: [] });
+      },
     }),
     {
       name: "donezo:board-collapsed:v1",
       storage: createJSONStorage(() =>
         typeof window === "undefined" ? noopStorage : localStorage,
       ),
-      // NOTE: storage key name is historical (was collapse-only); now persists
-      // both collapse state and column prefs. Don't rename — would orphan
-      // existing localStorage entries.
+      // Persisted slices: collapsedByBoard, columnPrefsByBoard, outbox.
+      // Storage key name is historical (was collapse-only); not renamed to preserve
+      // existing entries. outbox added in Epic 08 — older entries hydrate with outbox: [].
       partialize: (state) => ({
         collapsedByBoard: state.collapsedByBoard,
         columnPrefsByBoard: state.columnPrefsByBoard,
+        outbox: state.outbox,
       }),
       // On rehydration, re-derive collapsedGroupIds for the active board (if any).
       // columnPrefsByBoard is consumed lazily — no re-derivation needed.
+      // outbox defaults to [] if missing (older clients that pre-date Epic 08).
       onRehydrateStorage: () => (state) => {
+        if (state && !Array.isArray(state.outbox)) {
+          state.outbox = [];
+        }
         if (!state?.boardId) return;
         const ids = state.collapsedByBoard[state.boardId] ?? [];
         state.collapsedGroupIds = new Set(ids);
@@ -569,3 +758,24 @@ export const useBoardStore = create<BoardState>()(
     },
   ),
 );
+
+// ============================================================================
+// Selector helpers (Epic 08 — Realtime)
+// ============================================================================
+
+/** Returns the deduped list of user_ids currently present (one entry per user, regardless of tab count). */
+export function selectPresentUserIds(state: BoardState): string[] {
+  return Object.keys(state.presence).filter((uid) => (state.presence[uid] ?? []).length > 0);
+}
+
+// epic 09 will consume
+/** Returns deduped user_ids currently viewing a specific task (any tab). */
+export function selectUsersViewingTask(state: BoardState, taskId: string): string[] {
+  const out: string[] = [];
+  for (const [uid, entries] of Object.entries(state.presence)) {
+    if (entries.some((e) => e.viewing.type === "task" && e.viewing.task_id === taskId)) {
+      out.push(uid);
+    }
+  }
+  return out;
+}

--- a/stores/types/realtime.ts
+++ b/stores/types/realtime.ts
@@ -1,0 +1,48 @@
+export type ConnectionStatus = "connected" | "reconnecting" | "offline";
+
+// viewing.type is "board" today; "task" is forward-compat for Epic 09 (task drawer).
+// task_id is only set when type === "task".
+export type PresenceViewing = { type: "board" } | { type: "task"; task_id: string };
+
+export type PresenceEntry = {
+  user_id: string;
+  online_at: number; // epoch ms
+  viewing: PresenceViewing;
+};
+
+// Supabase Realtime presence state: keyed by presence key (we use userId),
+// each value is an array of one entry per active tab/connection for that user.
+export type PresenceState = Record<string, PresenceEntry[]>;
+
+// Broadcast: cursor position in the table view.
+export type CursorPayload = {
+  user_id: string;
+  task_id: string;
+  column_id: string;
+  at: number; // epoch ms — used to expire stale cursors
+};
+
+// Broadcast: typing indicator. `context` is opaque (e.g. `comment:<task_id>`).
+export type TypingPayload = {
+  user_id: string;
+  context: string;
+  at: number; // epoch ms — used to expire after 5s
+};
+
+// ----- Outbox -----
+// Queueable actions: upsert-style only. Inserts/deletes do NOT queue and must
+// error immediately when offline (handled by S8's wrapper, not by the store).
+export type OutboxActionId =
+  | "setCellValue"
+  | "bulkSetCellValue"
+  | "renameGroup"
+  | "renameTask"
+  | "updateTaskFields"; // any future task-field upsert
+
+export type OutboxEntry = {
+  id: string; // uuid v4 generated client-side ONLY for de-duplication of the outbox itself; NOT a DB id
+  actionId: OutboxActionId;
+  args: unknown[]; // serialized server-action args; server action validates via Zod on flush
+  optimisticUpdatedAt: number; // epoch ms, used purely for ordering/visibility
+  enqueuedAt: number; // epoch ms
+};

--- a/stores/types/realtime.ts
+++ b/stores/types/realtime.ts
@@ -32,12 +32,11 @@ export type TypingPayload = {
 // ----- Outbox -----
 // Queueable actions: upsert-style only. Inserts/deletes do NOT queue and must
 // error immediately when offline (handled by S8's wrapper, not by the store).
-export type OutboxActionId =
-  | "setCellValue"
-  | "bulkSetCellValue"
-  | "renameGroup"
-  | "renameTask"
-  | "updateTaskFields"; // any future task-field upsert
+// S8 deviation: `updateTaskFields` removed from this union because tasks/actions.ts
+// does not export a function by that name as of Epic 08. The registry in
+// lib/realtime/outbox-registry.ts covers the four existing upsert-style actions.
+// Add `updateTaskFields` (or a more specific name) here when a future epic ships it.
+export type OutboxActionId = "setCellValue" | "bulkSetCellValue" | "renameGroup" | "renameTask";
 
 export type OutboxEntry = {
   id: string; // uuid v4 generated client-side ONLY for de-duplication of the outbox itself; NOT a DB id

--- a/supabase/migrations/20260512000000_realtime_denormalization.sql
+++ b/supabase/migrations/20260512000000_realtime_denormalization.sql
@@ -1,0 +1,45 @@
+-- Epic 08 — denormalize board_id onto cell + comment so Realtime postgres_changes
+-- can filter board_id=eq.<id>. Defense-in-depth consistency triggers mirror the
+-- existing task_board_id_consistency pattern.
+
+-- 1. Add columns (nullable initially so backfill can run before NOT NULL is enforced).
+alter table public.cell    add column board_id uuid references public.board(id) on delete cascade;
+alter table public.comment add column board_id uuid references public.board(id) on delete cascade;
+
+-- 2. Backfill from task.board_id (task already carries it, kept in sync by task_board_id_consistency).
+update public.cell    set board_id = (select board_id from public.task where id = cell.task_id);
+update public.comment set board_id = (select board_id from public.task where id = comment.task_id);
+
+-- 3. Enforce NOT NULL post-backfill.
+alter table public.cell    alter column board_id set not null;
+alter table public.comment alter column board_id set not null;
+
+-- 4. Indexes for the filter and for FK joins.
+create index cell_board_idx    on public.cell(board_id);
+create index comment_board_idx on public.comment(board_id);
+
+-- 5. Defense-in-depth consistency triggers — mirror task_board_id_consistency
+--    pattern from the initial schema migration (lines 398–408). These derive
+--    board_id from the parent task on insert/update, so even a buggy server
+--    action that forgets to set board_id cannot break the invariant.
+create or replace function public.cell_board_id_consistency()
+returns trigger language plpgsql as $$
+begin
+  new.board_id = (select board_id from public.task where id = new.task_id);
+  return new;
+end $$;
+
+create trigger cell_board_id_consistency
+  before insert or update of task_id on public.cell
+  for each row execute function public.cell_board_id_consistency();
+
+create or replace function public.comment_board_id_consistency()
+returns trigger language plpgsql as $$
+begin
+  new.board_id = (select board_id from public.task where id = new.task_id);
+  return new;
+end $$;
+
+create trigger comment_board_id_consistency
+  before insert or update of task_id on public.comment
+  for each row execute function public.comment_board_id_consistency();

--- a/tests/e2e/08-realtime.spec.ts
+++ b/tests/e2e/08-realtime.spec.ts
@@ -1,0 +1,279 @@
+// @ts-expect-error playwright wired in epic 15
+import { expect, test } from "@playwright/test";
+
+/**
+ * Spec stub — runner wired in epic 15. Requires seeded users + Playwright config
+ * with two browser contexts (two authenticated users) pointed at a local
+ * Supabase stack (`pnpm supabase start && pnpm dev`).
+ *
+ * TODO (epic 15):
+ *  - Seed two users (USER_A and USER_B) with access to the same board in the
+ *    Supabase test DB via a setup script.
+ *  - Seed at least one group (with tasks t1, t2) and one column (c1) in board B.
+ *  - Configure `playwright.config.ts` with `baseURL` and two `storageState` files
+ *    (one per user) so sign-in persists without re-logging in.
+ *  - Replace placeholder values below with values emitted by the seed script.
+ *  - Set `context.setOffline(true)` behavior: confirmed to block websockets.
+ *    If Supabase Realtime WS is NOT blocked by setOffline on the CI environment,
+ *    use `context.route('**/ realtime; /**', route => route.abort())` as the fallback.
+ */
+
+// ---------------------------------------------------------------------------
+// Constants — replace with seed-script output in epic 15
+// ---------------------------------------------------------------------------
+const USER_A_EMAIL = "user-a+e2e@donezo.local";
+const USER_A_PASSWORD = "test-password-12345";
+const USER_B_EMAIL = "user-b+e2e@donezo.local";
+const USER_B_PASSWORD = "test-password-12345";
+const WORKSPACE_SLUG = "e2e-workspace";
+const BOARD_ID = "REPLACE_WITH_SEED_BOARD_ID";
+const BOARD_URL = `/w/${WORKSPACE_SLUG}/b/${BOARD_ID}`;
+// Seed task + column ids for cursor/cell tests
+const TASK_ID_T1 = "REPLACE_WITH_SEED_TASK_T1";
+const COLUMN_ID_C1 = "REPLACE_WITH_SEED_COLUMN_C1";
+const CELL_TEST_VALUE = `e2e-val-${Date.now()}`;
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+test.describe("Epic 08 — Realtime & Presence", () => {
+  // Skip all tests until epic 15 wires the Playwright runner and fixtures.
+  test.skip(
+    true,
+    "Spec stub — runner wired in epic 15. Requires seeded users, Playwright config, and local Supabase stack.",
+  );
+
+  // ── Test 1: Live cell edit ────────────────────────────────────────────────
+  /**
+   * Both users open board B. User A edits cell (t1, c1) to a new value.
+   * Within 1500ms User B's DOM reflects that value via Realtime postgres_changes.
+   */
+  test("1 — live cell edit: User A edits → User B sees update within 1500ms", async ({
+    browser,
+  }) => {
+    // TODO epic 15: use storageState to avoid re-login
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    // Sign in both users
+    for (const [page, email, pwd] of [
+      [pageA, USER_A_EMAIL, USER_A_PASSWORD],
+      [pageB, USER_B_EMAIL, USER_B_PASSWORD],
+    ] as const) {
+      await page.goto("/sign-in");
+      await page.getByLabel("Email").fill(email);
+      await page.getByLabel("Password").fill(pwd);
+      await page.getByRole("button", { name: /sign in/i }).click();
+    }
+
+    // Both navigate to the board
+    await pageA.goto(BOARD_URL);
+    await pageB.goto(BOARD_URL);
+
+    // User A edits the cell (t1, c1) — click the cell to activate the editor
+    const cellA = pageA.locator(`[data-task-id="${TASK_ID_T1}"][data-column-id="${COLUMN_ID_C1}"]`);
+    await cellA.click();
+    await pageA.keyboard.type(CELL_TEST_VALUE);
+    await pageA.keyboard.press("Enter");
+
+    // User B should see the new value within 1500ms (Realtime postgres_changes)
+    await expect
+      .poll(
+        async () => {
+          const cellB = pageB.locator(
+            `[data-task-id="${TASK_ID_T1}"][data-column-id="${COLUMN_ID_C1}"]`,
+          );
+          return cellB.textContent();
+        },
+        { timeout: 1500, intervals: [100] },
+      )
+      .toContain(CELL_TEST_VALUE);
+
+    await contextA.close();
+    await contextB.close();
+  });
+
+  // ── Test 2: Live task add ─────────────────────────────────────────────────
+  /**
+   * User A adds a task via AddTaskFooter. User B sees the task appear within
+   * 1500ms via Realtime postgres_changes on the `task` table.
+   */
+  test("2 — live task add: User A adds task → User B sees it within 1500ms", async ({
+    browser,
+  }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    await pageA.goto(BOARD_URL);
+    await pageB.goto(BOARD_URL);
+
+    const newTaskName = `Realtime task ${Date.now()}`;
+
+    // User A adds a task
+    await pageA
+      .getByRole("button", { name: /add task/i })
+      .first()
+      .click();
+    await pageA.getByRole("textbox", { name: /task title/i }).fill(newTaskName);
+    await pageA.keyboard.press("Enter");
+
+    // User B should see the new task appear within 1500ms
+    await expect
+      .poll(
+        async () => {
+          return pageB.getByText(newTaskName).isVisible();
+        },
+        { timeout: 1500, intervals: [100] },
+      )
+      .toBe(true);
+
+    await contextA.close();
+    await contextB.close();
+  });
+
+  // ── Test 3: Presence pile ─────────────────────────────────────────────────
+  /**
+   * Both users on the board → each sees 1 avatar (the other user) in PresencePile.
+   * User A navigates away → User B's pile shows 0 other users.
+   */
+  test("3 — presence pile: both users see each other; pile updates on navigate away", async ({
+    browser,
+  }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    await pageA.goto(BOARD_URL);
+    await pageB.goto(BOARD_URL);
+
+    // Each user should see exactly 1 avatar in the PresencePile (the other user).
+    // PresencePile excludes the current user; 2 users total means each sees 1.
+    const presencePileA = pageA.locator("[data-testid='presence-pile']");
+    const presencePileB = pageB.locator("[data-testid='presence-pile']");
+
+    await expect
+      .poll(async () => presencePileA.locator("[data-testid='presence-avatar']").count(), {
+        timeout: 3000,
+      })
+      .toBe(1);
+
+    await expect
+      .poll(async () => presencePileB.locator("[data-testid='presence-avatar']").count(), {
+        timeout: 3000,
+      })
+      .toBe(1);
+
+    // User A navigates away from the board
+    await pageA.goto("/");
+
+    // User B's pile should update to 0 other users within 5s
+    await expect
+      .poll(async () => presencePileB.locator("[data-testid='presence-avatar']").count(), {
+        timeout: 5000,
+        intervals: [200],
+      })
+      .toBe(0);
+
+    await contextA.close();
+    await contextB.close();
+  });
+
+  // ── Test 4: Connection status ─────────────────────────────────────────────
+  /**
+   * Force User A offline → the reconnecting/offline pill appears in A's topbar
+   * within 5s. Restore online → pill disappears within 10s; User A sees B's
+   * edit made while A was offline (router.refresh() re-fetches RSC).
+   */
+  test("4 — connection status: offline pill appears; reconnect syncs missed edits", async ({
+    browser,
+  }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    await pageA.goto(BOARD_URL);
+    await pageB.goto(BOARD_URL);
+
+    // Force User A offline — this blocks WebSocket connections to Supabase Realtime
+    await contextA.setOffline(true);
+
+    // The reconnecting/offline pill should appear in A's topbar within 5s
+    const connectionPill = pageA.locator("[data-testid='connection-status']");
+    await expect
+      .poll(async () => connectionPill.isVisible(), { timeout: 5000, intervals: [200] })
+      .toBe(true);
+
+    // User B edits a cell while User A is offline
+    const offlineTestValue = `offline-val-${Date.now()}`;
+    const cellB = pageB.locator(`[data-task-id="${TASK_ID_T1}"][data-column-id="${COLUMN_ID_C1}"]`);
+    await cellB.click();
+    await pageB.keyboard.type(offlineTestValue);
+    await pageB.keyboard.press("Enter");
+
+    // Restore User A online
+    await contextA.setOffline(false);
+
+    // Connection pill should disappear within 10s (reconnect + router.refresh())
+    await expect
+      .poll(async () => connectionPill.isVisible(), { timeout: 10000, intervals: [500] })
+      .toBe(false);
+
+    // User A should now see the value User B wrote while A was offline
+    // (router.refresh() rehydrates the RSC tree which re-fetches DB data)
+    await expect
+      .poll(
+        async () => {
+          const cellA = pageA.locator(
+            `[data-task-id="${TASK_ID_T1}"][data-column-id="${COLUMN_ID_C1}"]`,
+          );
+          return cellA.textContent();
+        },
+        { timeout: 5000, intervals: [200] },
+      )
+      .toContain(offlineTestValue);
+
+    await contextA.close();
+    await contextB.close();
+  });
+
+  // ── Test 5: Cursor dot ────────────────────────────────────────────────────
+  /**
+   * User A hovers cell (t1, c1). Within 500ms User B sees a colored dot in
+   * that cell (rendered by CursorOverlay).
+   */
+  test("5 — cursor dot: User A hover → User B sees colored dot within 500ms", async ({
+    browser,
+  }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    await pageA.goto(BOARD_URL);
+    await pageB.goto(BOARD_URL);
+
+    // User A hovers over the cell — triggers useCursorBroadcast.emit()
+    const cellA = pageA.locator(`[data-task-id="${TASK_ID_T1}"][data-column-id="${COLUMN_ID_C1}"]`);
+    await cellA.hover();
+
+    // User B should see a cursor dot inside that cell within 500ms
+    // CursorOverlay renders role="presentation" wrapper with a colored dot
+    const cursorDotInB = pageB
+      .locator(`[data-task-id="${TASK_ID_T1}"][data-column-id="${COLUMN_ID_C1}"]`)
+      .locator("[data-testid='cursor-dot']");
+
+    await expect
+      .poll(async () => cursorDotInB.count(), { timeout: 500, intervals: [50] })
+      .toBeGreaterThan(0);
+
+    await contextA.close();
+    await contextB.close();
+  });
+});

--- a/tests/policies/board_id_consistency.spec.sql
+++ b/tests/policies/board_id_consistency.spec.sql
@@ -1,0 +1,122 @@
+-- ============================================================
+-- tests/policies/board_id_consistency.spec.sql
+-- pgTAP assertions for the Epic 08 S0 board_id consistency triggers.
+--
+-- Assertion count: 2
+--
+-- Coverage targets:
+--   - Inserting a cell with the wrong board_id results in the row
+--     landing with the task's board_id (trigger overwrites).
+--   - Inserting a comment with the wrong board_id results in the
+--     row landing with the task's board_id (trigger overwrites).
+-- ============================================================
+
+begin;
+
+select plan(2);
+
+\i 00_setup.sql
+
+-- ============================================================
+-- Seed data (service-role context)
+-- ============================================================
+
+do $$
+begin
+  -- Users
+  perform tests.make_user('a8000000-0000-0000-0000-000000000001'::uuid, 'owner@test8.example');
+
+  -- Workspace + board
+  perform tests.seed_workspace_with_roles(
+    'b8000000-0000-0000-0000-000000000001'::uuid,
+    jsonb_build_object('a8000000-0000-0000-0000-000000000001', 'owner')
+  );
+
+  perform tests.seed_board(
+    'c8000000-0000-0000-0000-000000000001'::uuid,
+    'b8000000-0000-0000-0000-000000000001'::uuid,
+    false
+  );
+
+  -- A second board (used as the "wrong" board_id in insert payloads)
+  perform tests.seed_board(
+    'c8000000-0000-0000-0000-000000000002'::uuid,
+    'b8000000-0000-0000-0000-000000000001'::uuid,
+    false
+  );
+
+  -- Group on board 1
+  perform tests.seed_group(
+    'd8000000-0000-0000-0000-000000000001'::uuid,
+    'c8000000-0000-0000-0000-000000000001'::uuid
+  );
+
+  -- Task on board 1 (task.board_id = c8...001)
+  perform tests.seed_task(
+    'e8000000-0000-0000-0000-000000000001'::uuid,
+    'd8000000-0000-0000-0000-000000000001'::uuid,
+    'c8000000-0000-0000-0000-000000000001'::uuid
+  );
+
+  -- Column on board 1 (for the cell insert)
+  perform tests.seed_column(
+    'f8000000-0000-0000-0000-000000000001'::uuid,
+    'c8000000-0000-0000-0000-000000000001'::uuid
+  );
+end $$;
+
+-- ============================================================
+-- Test 1: cell trigger overwrites wrong board_id on insert.
+--
+-- We insert a cell providing board_id = c8...002 (board 2),
+-- but the task belongs to c8...001 (board 1). The trigger
+-- cell_board_id_consistency must set board_id to c8...001.
+-- ============================================================
+
+insert into public.cell (task_id, column_id, board_id, text_value)
+values (
+  'e8000000-0000-0000-0000-000000000001'::uuid,
+  'f8000000-0000-0000-0000-000000000001'::uuid,
+  'c8000000-0000-0000-0000-000000000002'::uuid,  -- intentionally wrong
+  'trigger test value'
+);
+
+select is(
+  (select board_id::text
+     from public.cell
+    where task_id   = 'e8000000-0000-0000-0000-000000000001'
+      and column_id = 'f8000000-0000-0000-0000-000000000001'),
+  'c8000000-0000-0000-0000-000000000001',
+  'cell_board_id_consistency trigger overwrites wrong board_id with task''s board_id on insert'
+);
+
+-- ============================================================
+-- Test 2: comment trigger overwrites wrong board_id on insert.
+--
+-- We insert a comment providing board_id = c8...002 (board 2),
+-- but the task belongs to c8...001 (board 1). The trigger
+-- comment_board_id_consistency must set board_id to c8...001.
+-- ============================================================
+
+insert into public.comment (id, task_id, author_id, board_id, body, body_text)
+values (
+  'g8000000-0000-0000-0000-000000000001'::uuid,
+  'e8000000-0000-0000-0000-000000000001'::uuid,
+  'a8000000-0000-0000-0000-000000000001'::uuid,
+  'c8000000-0000-0000-0000-000000000002'::uuid,  -- intentionally wrong
+  '{"type":"doc","content":[]}'::jsonb,
+  'trigger test comment'
+);
+
+select is(
+  (select board_id::text
+     from public.comment
+    where id = 'g8000000-0000-0000-0000-000000000001'),
+  'c8000000-0000-0000-0000-000000000001',
+  'comment_board_id_consistency trigger overwrites wrong board_id with task''s board_id on insert'
+);
+
+select tests.reset_to_service_role();
+
+select * from finish();
+rollback;

--- a/tests/unit/BoardTable-realtime-mount.test.tsx
+++ b/tests/unit/BoardTable-realtime-mount.test.tsx
@@ -1,0 +1,306 @@
+// @ts-expect-error vitest is wired in epic 15
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Unit test for Epic 08 S5 — verifies that BoardTable:
+ *  1. Calls useBoardRealtime(boardId, userId) on mount.
+ *  2. Calls flushOutbox() when the store connection transitions to 'connected'.
+ *  3. Calls flushOutbox() on the window 'online' event.
+ *  4. Removes all listeners on unmount.
+ *
+ * Strategy: mock heavy dependencies (hooks, store, context) so this test
+ * remains a pure unit test with no real Supabase, Next.js router, or DOM
+ * rendering complexity.
+ */
+
+// ---------------------------------------------------------------------------
+// Mock useBoardRealtime — the hook under test is that it gets CALLED,
+// not what it does internally (S2's test covers internals).
+// ---------------------------------------------------------------------------
+const mockUseBoardRealtime = vi.fn();
+
+vi.mock("../../hooks/use-board-realtime", () => ({
+  useBoardRealtime: (...args: unknown[]) => mockUseBoardRealtime(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock flushOutbox
+// ---------------------------------------------------------------------------
+const mockFlushOutbox = vi.fn().mockResolvedValue({ flushed: 0, dropped: 0 });
+
+vi.mock("../../lib/realtime/outbox", () => ({
+  flushOutbox: (...args: unknown[]) => mockFlushOutbox(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock useBoard — provide stable boardId + userId through context
+// ---------------------------------------------------------------------------
+const mockUseBoardValue = {
+  board: {
+    id: "board-abc",
+    name: "Test Board",
+    description: "",
+    is_private: false,
+    workspace_id: "ws-1",
+    created_by: "user-1",
+    deleted_at: null,
+  },
+  role: "owner" as const,
+  isStarred: false,
+  userId: "user-42",
+};
+
+vi.mock("../../hooks/use-board", () => ({
+  useBoard: () => mockUseBoardValue,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the heavy board-table sub-components so we can render BoardTable in
+// isolation. We only care about the effects, not the full render tree.
+// ---------------------------------------------------------------------------
+vi.mock("../../components/board/table/StickyHeader", () => ({
+  StickyHeader: () => null,
+}));
+
+vi.mock("../../components/board/table/TableVirtualizer", () => ({
+  TableVirtualizer: () => null,
+}));
+
+vi.mock("../../components/board/table/DndProviders", () => ({
+  DndProviders: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("../../components/board/table/AddGroupFooter", () => ({
+  AddGroupFooter: () => null,
+}));
+
+vi.mock("../../components/board/table/BulkActionBar", () => ({
+  BulkActionBar: () => null,
+}));
+
+vi.mock("../../components/board/table/EmptyStates", () => ({
+  NoGroupsEmptyState: () => null,
+}));
+
+// Mock dnd-kit (used internally by BoardTable)
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => children,
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+  verticalListSortingStrategy: {},
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => "" } },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock useBoardStore — provide minimal store state + subscribe spy
+// ---------------------------------------------------------------------------
+
+// We'll capture the subscribe listener so we can manually trigger it.
+// Zustand v5: subscribe(listener) receives (state, prevState) — no selector overload.
+let capturedSubscribeListener:
+  | ((state: { connection: string }, prevState: { connection: string }) => void)
+  | null = null;
+const mockUnsubscribe = vi.fn();
+
+const mockStoreState = {
+  groups: [],
+  tasks: [],
+  cells: new Map(),
+  columns: [],
+  labelsByColumn: new Map(),
+  collapsedGroupIds: new Set<string>(),
+  collapsedByBoard: {},
+  columnPrefsByBoard: {},
+  selection: new Set<string>(),
+  draggingTaskId: null,
+  draggingGroupId: null,
+  editingTaskId: null,
+  tempIdMap: new Map(),
+  sortColumnId: null,
+  sortDirection: null,
+  boardId: "board-abc",
+  outbox: [],
+  outboxOverflow: false,
+  connection: "connected",
+  presence: {},
+  cursors: new Map(),
+  typingByContext: new Map(),
+};
+
+vi.mock("../../stores/board-store", () => {
+  const mockStore = Object.assign(
+    // The hook calls useBoardStore(selector) — return a no-op fn
+    (selector: (s: typeof mockStoreState) => unknown) => selector(mockStoreState),
+    {
+      getState: () => ({
+        ...mockStoreState,
+        hydrate: vi.fn(),
+        reset: vi.fn(),
+      }),
+      // Zustand v5: subscribe(listener) receives (state, prevState)
+      subscribe: (
+        listener: (state: { connection: string }, prevState: { connection: string }) => void,
+      ) => {
+        capturedSubscribeListener = listener;
+        return mockUnsubscribe;
+      },
+      setState: vi.fn(),
+    },
+  );
+  return {
+    useBoardStore: mockStore,
+    selectPresentUserIds: vi.fn(() => []),
+  };
+});
+
+// Suppress useTableKeyboardNav import chain
+vi.mock("../../hooks/use-table-keyboard-nav", () => ({
+  useTableKeyboardNav: () => ({
+    onKeyDown: vi.fn(),
+  }),
+}));
+
+vi.mock("../../components/board/table/table-keyboard-context", () => ({
+  TableKeyboardContext: {
+    Provider: ({ children }: { children: React.ReactNode }) => children,
+  },
+  useTableKeyboard: () => ({
+    registerTitleCellRef: vi.fn(),
+    registerGroupTitleRef: vi.fn(),
+    focusTaskTitle: vi.fn(),
+    focusGroupTitle: vi.fn(),
+    onKeyDown: vi.fn(),
+  }),
+}));
+
+vi.mock("../../components/board/table/table-scroll-context", () => ({
+  TableScrollContext: {
+    Provider: ({ children }: { children: React.ReactNode }) => children,
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+// @ts-expect-error vitest is wired in epic 15
+import { act, renderHook } from "@testing-library/react";
+import { useEffect } from "react";
+
+// We test the mount behavior by directly inspecting mock calls.
+// We can also use a thin wrapper that reproduces just the two critical effects:
+//
+//   1. useBoardRealtime(boardId, userId) — called at component top-level
+//   2. useEffect → window.addEventListener('online', ...) + useBoardStore.subscribe(...)
+//
+// This avoids the full component render complexity while precisely targeting
+// the S5 requirements.
+
+describe.skip("BoardTable — Epic 08 realtime mount (S5)", () => {
+  // We use a minimal functional hook that mirrors exactly what BoardTable does:
+  const useBoardTableRealtimeEffects = (boardId: string, userId: string) => {
+    // Simulates: useBoardRealtime(boardId, userId)
+    mockUseBoardRealtime(boardId, userId);
+
+    // Simulates: the flush trigger useEffect (Zustand v5 full-state subscribe)
+    useEffect(() => {
+      const onOnline = () => {
+        void mockFlushOutbox();
+      };
+      window.addEventListener("online", onOnline);
+
+      const { useBoardStore } = require("../../stores/board-store");
+      // Zustand v5: subscribe(listener) receives (state, prevState)
+      const unsub = useBoardStore.subscribe(
+        (state: { connection: string }, prevState: { connection: string }) => {
+          if (prevState.connection !== "connected" && state.connection === "connected") {
+            void mockFlushOutbox();
+          }
+        },
+      );
+
+      return () => {
+        window.removeEventListener("online", onOnline);
+        unsub();
+      };
+    }, []);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedSubscribeListener = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls useBoardRealtime with (boardId, userId) on mount", () => {
+    renderHook(() => useBoardTableRealtimeEffects("board-abc", "user-42"));
+
+    expect(mockUseBoardRealtime).toHaveBeenCalledTimes(1);
+    expect(mockUseBoardRealtime).toHaveBeenCalledWith("board-abc", "user-42");
+  });
+
+  it("subscribes to store on mount", () => {
+    renderHook(() => useBoardTableRealtimeEffects("board-abc", "user-42"));
+
+    expect(capturedSubscribeListener).toBeTruthy();
+  });
+
+  it("calls flushOutbox when store connection transitions to 'connected' from non-connected", () => {
+    renderHook(() => useBoardTableRealtimeEffects("board-abc", "user-42"));
+
+    // Simulate reconnecting → connected transition (Zustand v5: (state, prevState))
+    act(() => {
+      capturedSubscribeListener?.({ connection: "connected" }, { connection: "reconnecting" });
+    });
+
+    expect(mockFlushOutbox).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call flushOutbox when store transitions connected → connected", () => {
+    renderHook(() => useBoardTableRealtimeEffects("board-abc", "user-42"));
+
+    act(() => {
+      capturedSubscribeListener?.({ connection: "connected" }, { connection: "connected" });
+    });
+
+    expect(mockFlushOutbox).not.toHaveBeenCalled();
+  });
+
+  it("calls flushOutbox when window 'online' event fires", () => {
+    renderHook(() => useBoardTableRealtimeEffects("board-abc", "user-42"));
+
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+
+    expect(mockFlushOutbox).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes window 'online' listener and unsubscribes from store on unmount", () => {
+    const { unmount } = renderHook(() => useBoardTableRealtimeEffects("board-abc", "user-42"));
+
+    unmount();
+
+    // After unmount, the 'online' event should NOT call flushOutbox anymore
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+
+    expect(mockFlushOutbox).not.toHaveBeenCalled();
+
+    // useBoardStore.subscribe unsub should have been called
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/ConnectionStatus.test.tsx
+++ b/tests/unit/ConnectionStatus.test.tsx
@@ -1,0 +1,76 @@
+// @ts-expect-error @testing-library/react wired in epic 15
+import { render } from "@testing-library/react";
+// @ts-expect-error vitest is wired in epic 15
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ConnectionStatus } from "@/components/board/ConnectionStatus";
+import { useBoardStore } from "@/stores/board-store";
+import type { ConnectionStatus as ConnectionStatusType } from "@/stores/types/realtime";
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function setStatus(status: ConnectionStatusType) {
+  useBoardStore.setState({ connection: status });
+}
+
+// ---------------------------------------------------------------------------
+// Tests — deferred: vitest runner wired in epic 15
+// ---------------------------------------------------------------------------
+
+describe.skip("ConnectionStatus", () => {
+  beforeEach(() => {
+    // Reset to connected (the default / "invisible" state)
+    useBoardStore.setState({ connection: "connected" });
+  });
+
+  it("renders null when connected (no DOM output)", () => {
+    setStatus("connected");
+    const { container } = render(<ConnectionStatus />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a pill with aria-live=polite when reconnecting", () => {
+    setStatus("reconnecting");
+    const { getByRole } = render(<ConnectionStatus />);
+    const pill = getByRole("status");
+    expect(pill).toBeTruthy();
+    expect(pill.getAttribute("aria-live")).toBe("polite");
+    expect(pill.textContent).toContain("Reconnecting…");
+  });
+
+  it("renders a pill with aria-live=polite when offline", () => {
+    setStatus("offline");
+    const { getByRole } = render(<ConnectionStatus />);
+    const pill = getByRole("status");
+    expect(pill).toBeTruthy();
+    expect(pill.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("offline message matches the spec", () => {
+    setStatus("offline");
+    const { getByRole } = render(<ConnectionStatus />);
+    const pill = getByRole("status");
+    expect(pill.textContent).toBe("You're offline. Changes will sync when you reconnect.");
+  });
+
+  it("reconnecting shows animate-pulse on the dot", () => {
+    setStatus("reconnecting");
+    const { getByRole } = render(<ConnectionStatus />);
+    const pill = getByRole("status");
+    // The dot span is aria-hidden; select by querying inside the pill
+    const dot = pill.querySelector("[aria-hidden]");
+    expect(dot?.className).toContain("animate-pulse");
+    expect(dot?.className).toContain("bg-yellow-500");
+  });
+
+  it("offline shows red dot without animate-pulse", () => {
+    setStatus("offline");
+    const { getByRole } = render(<ConnectionStatus />);
+    const pill = getByRole("status");
+    const dot = pill.querySelector("[aria-hidden]");
+    expect(dot?.className).toContain("bg-red-500");
+    expect(dot?.className).not.toContain("animate-pulse");
+  });
+});

--- a/tests/unit/OutboxBanner.test.tsx
+++ b/tests/unit/OutboxBanner.test.tsx
@@ -1,0 +1,78 @@
+// @ts-expect-error @testing-library/react wired in epic 15
+import { render, screen } from "@testing-library/react";
+// @ts-expect-error vitest is wired in epic 15
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { OutboxBanner } from "@/components/board/OutboxBanner";
+import { useBoardStore } from "@/stores/board-store";
+
+// ---------------------------------------------------------------------------
+// Helper — seed outbox length without real entries
+// ---------------------------------------------------------------------------
+
+function seedOutboxCount(count: number) {
+  const entries = Array.from({ length: count }, (_, i) => ({
+    id: `entry-${i}`,
+    actionId: "setCellValue" as const,
+    args: [],
+    optimisticUpdatedAt: Date.now(),
+    enqueuedAt: Date.now() + i,
+  }));
+  useBoardStore.setState({ outbox: entries });
+}
+
+// ---------------------------------------------------------------------------
+// Tests — deferred: vitest runner wired in epic 15
+// ---------------------------------------------------------------------------
+
+describe.skip("OutboxBanner", () => {
+  beforeEach(() => {
+    useBoardStore.setState({ outbox: [] });
+  });
+
+  it("returns null (no DOM output) when outbox is empty (count=0)", () => {
+    seedOutboxCount(0);
+    const { container } = render(<OutboxBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the banner with correct singular text for count=1", () => {
+    seedOutboxCount(1);
+    render(<OutboxBanner />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText(/Syncing 1 pending change…/)).toBeInTheDocument();
+  });
+
+  it("renders the banner with correct plural text for count=5", () => {
+    seedOutboxCount(5);
+    render(<OutboxBanner />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText(/Syncing 5 pending changes…/)).toBeInTheDocument();
+  });
+
+  it("has aria-live='polite' on the status element", () => {
+    seedOutboxCount(2);
+    render(<OutboxBanner />);
+    const statusEl = screen.getByRole("status");
+    expect(statusEl).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("renders the pulsing yellow dot inside the banner", () => {
+    seedOutboxCount(3);
+    const { container } = render(<OutboxBanner />);
+    // The dot is a span with animate-pulse class
+    const dot = container.querySelector(".animate-pulse");
+    expect(dot).toBeInTheDocument();
+  });
+
+  it("updates reactively when the outbox count changes", () => {
+    seedOutboxCount(0);
+    const { rerender } = render(<OutboxBanner />);
+    expect(screen.queryByRole("status")).toBeNull();
+
+    seedOutboxCount(3);
+    rerender(<OutboxBanner />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText(/Syncing 3 pending changes…/)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/PresencePile.test.tsx
+++ b/tests/unit/PresencePile.test.tsx
@@ -1,0 +1,169 @@
+// @ts-expect-error @testing-library/react wired in epic 15
+import { render } from "@testing-library/react";
+// @ts-expect-error vitest is wired in epic 15
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PresencePile } from "@/components/board/PresencePile";
+import { useBoardStore } from "@/stores/board-store";
+import type { PresenceState } from "@/stores/types/realtime";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function seedPresence(state: PresenceState) {
+  useBoardStore.setState({ presence: state });
+}
+
+const MEMBERS = [
+  { id: "user-1", displayName: "Alice", email: "alice@example.com", avatarUrl: null },
+  { id: "user-2", displayName: "Bob", email: "bob@example.com", avatarUrl: null },
+  { id: "user-3", displayName: "Carol", email: "carol@example.com", avatarUrl: null },
+  { id: "user-4", displayName: "Dave", email: "dave@example.com", avatarUrl: null },
+  { id: "user-5", displayName: "Eve", email: "eve@example.com", avatarUrl: null },
+];
+
+const CURRENT_USER = "user-0";
+
+// ---------------------------------------------------------------------------
+// Tests — deferred: vitest runner wired in epic 15
+// ---------------------------------------------------------------------------
+
+// Mocks needed at module level (wired in epic 15 with proper jsdom + setup file)
+vi.mock("@base-ui/react", () => ({
+  Tooltip: {
+    Provider: ({ children }: { children: React.ReactNode }) => children,
+    Root: ({ children }: { children: React.ReactNode }) => children,
+    Trigger: ({
+      render: renderEl,
+      children,
+    }: {
+      render: React.ReactElement;
+      children?: React.ReactNode;
+    }) => (
+      <>
+        {renderEl}
+        {children}
+      </>
+    ),
+    Portal: ({ children }: { children: React.ReactNode }) => children,
+    Positioner: ({ children }: { children: React.ReactNode }) => children,
+    Popup: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+      <div className={className}>{children}</div>
+    ),
+  },
+}));
+
+describe.skip("PresencePile", () => {
+  beforeEach(() => {
+    // Reset store presence to empty between tests
+    useBoardStore.setState({ presence: {} });
+  });
+
+  it("renders null when no other users are present", () => {
+    seedPresence({});
+    const { container } = render(<PresencePile members={MEMBERS} currentUserId={CURRENT_USER} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders null when only the current user is present", () => {
+    seedPresence({
+      [CURRENT_USER]: [
+        { user_id: CURRENT_USER, online_at: Date.now(), viewing: { type: "board" } },
+      ],
+    });
+    const { container } = render(<PresencePile members={MEMBERS} currentUserId={CURRENT_USER} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders 1 avatar when 1 other user is present", () => {
+    seedPresence({
+      "user-1": [{ user_id: "user-1", online_at: Date.now(), viewing: { type: "board" } }],
+    });
+    const { getAllByRole } = render(
+      <PresencePile members={MEMBERS} currentUserId={CURRENT_USER} />,
+    );
+    // Avatar renders as role="img" (span with role="img") for fallback avatars
+    const imgs = getAllByRole("img");
+    expect(imgs).toHaveLength(1);
+  });
+
+  it("renders up to max avatars (default 4) and shows +N surplus chip", () => {
+    // 8 users present (excluding current user who is user-0)
+    const state: PresenceState = {};
+    for (let i = 1; i <= 8; i++) {
+      state[`user-${i}`] = [
+        { user_id: `user-${i}`, online_at: Date.now(), viewing: { type: "board" } },
+      ];
+    }
+    seedPresence(state);
+
+    const { getByLabelText } = render(
+      <PresencePile members={MEMBERS} currentUserId={CURRENT_USER} />,
+    );
+    // surplus = 8 - 4 = 4
+    const chip = getByLabelText("4 more users viewing");
+    expect(chip).toBeTruthy();
+    expect(chip.textContent).toBe("+4");
+  });
+
+  it("respects custom max prop", () => {
+    const state: PresenceState = {};
+    for (let i = 1; i <= 5; i++) {
+      state[`user-${i}`] = [
+        { user_id: `user-${i}`, online_at: Date.now(), viewing: { type: "board" } },
+      ];
+    }
+    seedPresence(state);
+
+    const { getByLabelText } = render(
+      <PresencePile members={MEMBERS} currentUserId={CURRENT_USER} max={2} />,
+    );
+    // surplus = 5 - 2 = 3
+    const chip = getByLabelText("3 more users viewing");
+    expect(chip.textContent).toBe("+3");
+  });
+
+  it("excludes current user from the pile", () => {
+    // Only current user in presence — should render null
+    seedPresence({
+      [CURRENT_USER]: [
+        { user_id: CURRENT_USER, online_at: Date.now(), viewing: { type: "board" } },
+      ],
+    });
+    const { container } = render(<PresencePile members={MEMBERS} currentUserId={CURRENT_USER} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("falls back gracefully for unknown presence ids (not in members list)", () => {
+    // "unknown-user" is not in MEMBERS — should still render with ? fallback
+    seedPresence({
+      "unknown-user": [
+        { user_id: "unknown-user", online_at: Date.now(), viewing: { type: "board" } },
+      ],
+    });
+    const { getAllByRole } = render(
+      <PresencePile members={MEMBERS} currentUserId={CURRENT_USER} />,
+    );
+    // Should render one avatar with the fallback "?" initial
+    const imgs = getAllByRole("img");
+    expect(imgs).toHaveLength(1);
+    expect(imgs[0]?.textContent).toBe("?");
+  });
+
+  it("deduplicates multi-tab presence (same user_id across tabs shows as one avatar)", () => {
+    // user-1 has 2 tabs open
+    seedPresence({
+      "user-1": [
+        { user_id: "user-1", online_at: Date.now(), viewing: { type: "board" } },
+        { user_id: "user-1", online_at: Date.now() - 1000, viewing: { type: "board" } },
+      ],
+    });
+    const { getAllByRole } = render(
+      <PresencePile members={MEMBERS} currentUserId={CURRENT_USER} />,
+    );
+    // selectPresentUserIds dedupes by user_id key — only 1 avatar shown
+    const imgs = getAllByRole("img");
+    expect(imgs).toHaveLength(1);
+  });
+});

--- a/tests/unit/board-store.test.ts
+++ b/tests/unit/board-store.test.ts
@@ -45,6 +45,7 @@ function makeTask(overrides: Partial<Task> = {}): Task {
 function makeCell(overrides: Partial<Cell> = {}): Cell {
   return {
     task_id: "task-1",
+    board_id: "board-1",
     column_id: "col-1",
     text_value: "hello",
     boolean_value: null,

--- a/tests/unit/board-store.test.ts
+++ b/tests/unit/board-store.test.ts
@@ -2,7 +2,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Database } from "../../lib/supabase/types";
-import { useBoardStore } from "../../stores/board-store";
+import {
+  selectPresentUserIds,
+  selectUsersViewingTask,
+  useBoardStore,
+} from "../../stores/board-store";
+import type {
+  CursorPayload,
+  OutboxActionId,
+  PresenceState,
+  TypingPayload,
+} from "../../stores/types/realtime";
 
 type Group = Database["public"]["Tables"]["group"]["Row"];
 type Task = Database["public"]["Tables"]["task"]["Row"];
@@ -398,5 +408,330 @@ describe.skip("useBoardStore", () => {
       const value = noopStorageLocal.getItem("donezo:board-collapsed:v1");
       expect(value).toBeNull();
     }).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Epic 08 — realtime state
+// ---------------------------------------------------------------------------
+
+describe.skip("Epic 08 — realtime state", () => {
+  beforeEach(() => {
+    useBoardStore.getState().reset();
+    useBoardStore.setState({
+      collapsedByBoard: {},
+      outbox: [],
+      outboxOverflow: false,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // setConnectionStatus
+  // -------------------------------------------------------------------------
+
+  it("setConnectionStatus transitions to 'connected'", () => {
+    useBoardStore.getState().setConnectionStatus("offline");
+    useBoardStore.getState().setConnectionStatus("connected");
+    expect(useBoardStore.getState().connection).toBe("connected");
+  });
+
+  it("setConnectionStatus transitions to 'reconnecting'", () => {
+    useBoardStore.getState().setConnectionStatus("reconnecting");
+    expect(useBoardStore.getState().connection).toBe("reconnecting");
+  });
+
+  it("setConnectionStatus transitions to 'offline'", () => {
+    useBoardStore.getState().setConnectionStatus("offline");
+    expect(useBoardStore.getState().connection).toBe("offline");
+  });
+
+  // -------------------------------------------------------------------------
+  // setPresence + selectPresentUserIds
+  // -------------------------------------------------------------------------
+
+  it("setPresence overwrites presence state wholesale", () => {
+    const initial: PresenceState = {
+      "user-1": [{ user_id: "user-1", online_at: 1000, viewing: { type: "board" } }],
+    };
+    useBoardStore.getState().setPresence(initial);
+    expect(useBoardStore.getState().presence).toEqual(initial);
+
+    const updated: PresenceState = {
+      "user-2": [{ user_id: "user-2", online_at: 2000, viewing: { type: "board" } }],
+    };
+    useBoardStore.getState().setPresence(updated);
+    expect(useBoardStore.getState().presence).toEqual(updated);
+    expect(useBoardStore.getState().presence["user-1"]).toBeUndefined();
+  });
+
+  it("selectPresentUserIds returns deduped user_ids (one per user, regardless of tab count)", () => {
+    const state: PresenceState = {
+      "user-a": [
+        { user_id: "user-a", online_at: 1000, viewing: { type: "board" } },
+        { user_id: "user-a", online_at: 1001, viewing: { type: "board" } }, // second tab
+      ],
+      "user-b": [{ user_id: "user-b", online_at: 2000, viewing: { type: "board" } }],
+      "user-c": [], // empty — should NOT appear
+    };
+    useBoardStore.getState().setPresence(state);
+
+    const ids = selectPresentUserIds(useBoardStore.getState());
+    expect(ids).toContain("user-a");
+    expect(ids).toContain("user-b");
+    expect(ids).not.toContain("user-c");
+    expect(ids).toHaveLength(2);
+  });
+
+  it("selectUsersViewingTask returns only users viewing the specified task", () => {
+    const state: PresenceState = {
+      "user-x": [
+        { user_id: "user-x", online_at: 1000, viewing: { type: "task", task_id: "task-99" } },
+      ],
+      "user-y": [
+        { user_id: "user-y", online_at: 2000, viewing: { type: "task", task_id: "task-99" } },
+        { user_id: "user-y", online_at: 2001, viewing: { type: "board" } }, // another tab on board
+      ],
+      "user-z": [
+        { user_id: "user-z", online_at: 3000, viewing: { type: "task", task_id: "task-other" } },
+      ],
+    };
+    useBoardStore.getState().setPresence(state);
+
+    const viewers = selectUsersViewingTask(useBoardStore.getState(), "task-99");
+    expect(viewers).toContain("user-x");
+    expect(viewers).toContain("user-y");
+    expect(viewers).not.toContain("user-z");
+  });
+
+  // -------------------------------------------------------------------------
+  // setCursor + pruneExpiredCursors
+  // -------------------------------------------------------------------------
+
+  it("setCursor upserts cursor per user_id", () => {
+    const cursor1: CursorPayload = { user_id: "u1", task_id: "t1", column_id: "c1", at: 1000 };
+    const cursor2: CursorPayload = { user_id: "u2", task_id: "t2", column_id: "c2", at: 2000 };
+
+    useBoardStore.getState().setCursor(cursor1);
+    useBoardStore.getState().setCursor(cursor2);
+
+    const { cursors } = useBoardStore.getState();
+    expect(cursors.get("u1")).toEqual(cursor1);
+    expect(cursors.get("u2")).toEqual(cursor2);
+
+    // Overwrite u1's cursor
+    const updated: CursorPayload = { user_id: "u1", task_id: "t99", column_id: "c99", at: 3000 };
+    useBoardStore.getState().setCursor(updated);
+    expect(useBoardStore.getState().cursors.get("u1")).toEqual(updated);
+  });
+
+  it("pruneExpiredCursors removes cursors where now - at > ttlMs", () => {
+    const now = 10000;
+    const ttlMs = 3000;
+
+    const fresh: CursorPayload = { user_id: "fresh", task_id: "t1", column_id: "c1", at: 8000 }; // 2s old
+    const stale: CursorPayload = { user_id: "stale", task_id: "t2", column_id: "c2", at: 5000 }; // 5s old
+
+    useBoardStore.getState().setCursor(fresh);
+    useBoardStore.getState().setCursor(stale);
+
+    useBoardStore.getState().pruneExpiredCursors(now, ttlMs);
+
+    const { cursors } = useBoardStore.getState();
+    expect(cursors.has("fresh")).toBe(true);
+    expect(cursors.has("stale")).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // setTyping + pruneExpiredTyping
+  // -------------------------------------------------------------------------
+
+  it("setTyping de-dupes per (context, user_id) — newer at overwrites older", () => {
+    const ctx = "comment:task-1";
+    const t1: TypingPayload = { user_id: "u1", context: ctx, at: 1000 };
+    const t1Updated: TypingPayload = { user_id: "u1", context: ctx, at: 2000 };
+    const t2: TypingPayload = { user_id: "u2", context: ctx, at: 1500 };
+
+    useBoardStore.getState().setTyping(t1);
+    useBoardStore.getState().setTyping(t2);
+    useBoardStore.getState().setTyping(t1Updated);
+
+    const { typingByContext } = useBoardStore.getState();
+    const entries = typingByContext.get(ctx) ?? [];
+    // u1 should appear exactly once with the newer at
+    const u1Entries = entries.filter((e) => e.user_id === "u1");
+    expect(u1Entries).toHaveLength(1);
+    expect(u1Entries[0]?.at).toBe(2000);
+    // u2 should also be present
+    expect(entries.some((e) => e.user_id === "u2")).toBe(true);
+  });
+
+  it("pruneExpiredTyping clears stale entries and removes empty context keys", () => {
+    const now = 10000;
+    const ttlMs = 5000;
+    const ctx = "comment:task-2";
+
+    const fresh: TypingPayload = { user_id: "u1", context: ctx, at: 6000 }; // 4s old — within TTL
+    const stale: TypingPayload = { user_id: "u2", context: ctx, at: 4000 }; // 6s old — expired
+
+    useBoardStore.getState().setTyping(fresh);
+    useBoardStore.getState().setTyping(stale);
+
+    useBoardStore.getState().pruneExpiredTyping(now, ttlMs);
+
+    const { typingByContext } = useBoardStore.getState();
+    const entries = typingByContext.get(ctx) ?? [];
+    expect(entries.some((e) => e.user_id === "u1")).toBe(true);
+    expect(entries.some((e) => e.user_id === "u2")).toBe(false);
+  });
+
+  it("pruneExpiredTyping removes the context key when all entries expire", () => {
+    const now = 10000;
+    const ttlMs = 5000;
+    const ctx = "comment:task-3";
+
+    const stale: TypingPayload = { user_id: "u1", context: ctx, at: 1000 }; // 9s old — expired
+    useBoardStore.getState().setTyping(stale);
+
+    useBoardStore.getState().pruneExpiredTyping(now, ttlMs);
+
+    const { typingByContext } = useBoardStore.getState();
+    expect(typingByContext.has(ctx)).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // enqueueOutbox + dequeueOutbox + clearOutbox
+  // -------------------------------------------------------------------------
+
+  it("enqueueOutbox generates id and enqueuedAt", () => {
+    const actionId: OutboxActionId = "setCellValue";
+    useBoardStore.getState().enqueueOutbox({
+      actionId,
+      args: ["arg1", "arg2"],
+      optimisticUpdatedAt: Date.now(),
+    });
+
+    const { outbox } = useBoardStore.getState();
+    expect(outbox).toHaveLength(1);
+    const entry = outbox[0];
+    expect(entry).toBeDefined();
+    expect(typeof entry?.id).toBe("string");
+    expect(entry?.id.length).toBeGreaterThan(0);
+    expect(typeof entry?.enqueuedAt).toBe("number");
+    expect(entry?.actionId).toBe(actionId);
+    expect(entry?.args).toEqual(["arg1", "arg2"]);
+  });
+
+  it("dequeueOutbox removes the entry by id", () => {
+    useBoardStore.getState().enqueueOutbox({
+      actionId: "renameTask",
+      args: ["task-1", "New Name"],
+      optimisticUpdatedAt: Date.now(),
+    });
+    useBoardStore.getState().enqueueOutbox({
+      actionId: "renameGroup",
+      args: ["group-1", "New Group"],
+      optimisticUpdatedAt: Date.now(),
+    });
+
+    const { outbox: before } = useBoardStore.getState();
+    expect(before).toHaveLength(2);
+
+    const idToRemove = before[0]?.id ?? "";
+    useBoardStore.getState().dequeueOutbox(idToRemove);
+
+    const { outbox: after } = useBoardStore.getState();
+    expect(after).toHaveLength(1);
+    expect(after[0]?.id).not.toBe(idToRemove);
+  });
+
+  it("clearOutbox empties the entire outbox", () => {
+    useBoardStore.getState().enqueueOutbox({
+      actionId: "setCellValue",
+      args: [],
+      optimisticUpdatedAt: Date.now(),
+    });
+    useBoardStore.getState().enqueueOutbox({
+      actionId: "bulkSetCellValue",
+      args: [],
+      optimisticUpdatedAt: Date.now(),
+    });
+
+    useBoardStore.getState().clearOutbox();
+
+    expect(useBoardStore.getState().outbox).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // enqueueOutbox — 4MB size cap
+  // -------------------------------------------------------------------------
+
+  it("enqueueOutbox refuses to push and sets outboxOverflow when serialized outbox > 4MB", () => {
+    // Construct a giant args payload: ~4MB of data
+    const bigString = "x".repeat(4 * 1024 * 1024 + 100); // slightly over 4MB
+
+    useBoardStore.getState().enqueueOutbox({
+      actionId: "setCellValue",
+      args: [bigString],
+      optimisticUpdatedAt: Date.now(),
+    });
+
+    const state = useBoardStore.getState();
+    // The giant entry itself is larger than the cap, so it must be rejected
+    expect(state.outboxOverflow).toBe(true);
+    // outbox should remain empty (or whatever it was before — not grown)
+    expect(state.outbox).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // reset — outbox preserved
+  // -------------------------------------------------------------------------
+
+  it("reset preserves outbox", () => {
+    useBoardStore.getState().enqueueOutbox({
+      actionId: "renameTask",
+      args: ["task-1", "New Title"],
+      optimisticUpdatedAt: Date.now(),
+    });
+
+    const { outbox: before } = useBoardStore.getState();
+    expect(before).toHaveLength(1);
+
+    // Set some transient state that should clear
+    useBoardStore.setState({
+      boardId: "board-x",
+      connection: "offline",
+    });
+
+    useBoardStore.getState().reset();
+
+    const { outbox: after, boardId, connection } = useBoardStore.getState();
+    // Outbox must survive the reset
+    expect(after).toHaveLength(1);
+    expect(after[0]?.actionId).toBe("renameTask");
+    // Transient state must be cleared
+    expect(boardId).toBeNull();
+    expect(connection).toBe("connected");
+  });
+
+  // -------------------------------------------------------------------------
+  // Rehydration — missing outbox field defaults to []
+  // -------------------------------------------------------------------------
+
+  it("rehydration with no outbox field defaults to []", () => {
+    // Directly test the onRehydrateStorage defaulting logic: simulate a state
+    // hydrated from older localStorage that has no outbox key.
+    // We exercise the guard inline (mirroring what the middleware calls).
+    const rehydratedState: Record<string, unknown> = {
+      collapsedByBoard: { "board-1": ["group-a"] },
+      columnPrefsByBoard: {},
+      // outbox intentionally omitted — simulates older localStorage entry
+    };
+
+    // Apply the same guard as onRehydrateStorage
+    if (!Array.isArray(rehydratedState.outbox)) {
+      rehydratedState.outbox = [];
+    }
+
+    expect(rehydratedState.outbox).toEqual([]);
   });
 });

--- a/tests/unit/cell-actions.test.ts
+++ b/tests/unit/cell-actions.test.ts
@@ -275,6 +275,115 @@ describe.skip("bulkSetCellValue", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Epic 08 — S0: board_id in upsert payloads
+// ---------------------------------------------------------------------------
+
+describe.skip("setCellValue — board_id in upsert payload (Epic 08 S0)", () => {
+  it("includes board_id from the column record in the upsert payload", async () => {
+    // Arrange — simulate the upsert payload construction from setCellValue.
+    // The action reads col.board_id after loading the column, then passes it
+    // explicitly so Realtime can filter on board_id=eq.<id>.
+    const mockPatch = {
+      text_value: "Hello",
+      number_value: null,
+      boolean_value: null,
+      date_value: null,
+      date_end_value: null,
+      label_id: null,
+      json_value: null,
+    };
+    const col = { id: "col-uuid", board_id: "board-uuid", type: "text" };
+    const input = { taskId: "task-uuid", columnId: "col-uuid", value: "Hello" };
+    const userId = "user-uuid";
+
+    // Act — simulate the upsert payload built inside setCellValue.
+    const upsertPayload = {
+      task_id: input.taskId,
+      column_id: input.columnId,
+      board_id: col.board_id,
+      ...mockPatch,
+      updated_by: userId,
+    };
+
+    // Assert — board_id must match the column's board_id.
+    expect(upsertPayload.board_id).toBe("board-uuid");
+    expect(upsertPayload.task_id).toBe("task-uuid");
+    expect(upsertPayload.column_id).toBe("col-uuid");
+  });
+
+  it("board_id in upsert payload matches col.board_id, not any task-derived value", async () => {
+    // Guardrail: the action takes board_id from the column lookup, not from
+    // client input. Verifies the source of truth is col.board_id.
+    const col = { id: "col-uuid", board_id: "expected-board-id", type: "text" };
+
+    const payload = {
+      task_id: "task-uuid",
+      column_id: col.id,
+      board_id: col.board_id, // must come from col, not from client input
+      text_value: "test",
+      updated_by: "user-uuid",
+    };
+
+    expect(payload.board_id).toBe(col.board_id);
+    expect(payload.board_id).toBe("expected-board-id");
+  });
+});
+
+describe.skip("bulkSetCellValue — board_id in upsert payload (Epic 08 S0)", () => {
+  it("includes board_id from the column record in every entry of the upsert payload", async () => {
+    // Arrange — simulate the bulk upsert payload construction.
+    // The action computes a single patch and maps it over all taskIds, including
+    // board_id: col.board_id in each entry.
+    const mockPatch = {
+      text_value: "Bulk value",
+      number_value: null,
+      boolean_value: null,
+      date_value: null,
+      date_end_value: null,
+      label_id: null,
+      json_value: null,
+    };
+    const col = { id: "col-uuid", board_id: "board-uuid", type: "text" };
+    const taskIds = ["task-1", "task-2", "task-3"];
+    const userId = "user-uuid";
+
+    // Act — simulate the upsert payload map inside bulkSetCellValue.
+    const upsertPayload = taskIds.map((tid) => ({
+      task_id: tid,
+      column_id: col.id,
+      board_id: col.board_id,
+      ...mockPatch,
+      updated_by: userId,
+    }));
+
+    // Assert — every entry must have board_id set.
+    expect(upsertPayload).toHaveLength(3);
+    expect(upsertPayload.every((p) => p.board_id === "board-uuid")).toBe(true);
+    expect(upsertPayload[0]?.board_id).toBe("board-uuid");
+    expect(upsertPayload[1]?.board_id).toBe("board-uuid");
+    expect(upsertPayload[2]?.board_id).toBe("board-uuid");
+  });
+
+  it("board_id is consistent across all entries regardless of task count", async () => {
+    // The board_id must be the same for every entry in a bulk call (single-board
+    // safety check ensures all tasks are on the same board as the column).
+    const boardId = "shared-board-id";
+    const col = { id: "col-uuid", board_id: boardId, type: "text" };
+    const taskIds = Array.from({ length: 10 }, (_, i) => `task-${i}`);
+
+    const upsertPayload = taskIds.map((tid) => ({
+      task_id: tid,
+      column_id: col.id,
+      board_id: col.board_id,
+    }));
+
+    const uniqueBoardIds = new Set(upsertPayload.map((p) => p.board_id));
+    expect(uniqueBoardIds.size).toBe(1);
+    expect(uniqueBoardIds.has(boardId)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Additional cases (S23 extension)
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/cursor-color.test.ts
+++ b/tests/unit/cursor-color.test.ts
@@ -1,0 +1,73 @@
+// @ts-expect-error vitest is wired in epic 15
+import { describe, expect, it } from "vitest";
+
+import { cursorColorForUser } from "../../lib/realtime/cursor-color";
+
+describe.skip("cursorColorForUser", () => {
+  it("returns a stable color for the same user_id", () => {
+    const userId = "user-abc-123";
+    const color1 = cursorColorForUser(userId);
+    const color2 = cursorColorForUser(userId);
+    expect(color1).toBe(color2);
+  });
+
+  it("returns different colors for distinct user_ids (most of the time)", () => {
+    const color1 = cursorColorForUser("user-aaa-111");
+    const color2 = cursorColorForUser("user-bbb-222");
+    const color3 = cursorColorForUser("user-ccc-333");
+    // Not all three should be the same
+    const allSame = color1 === color2 && color2 === color3;
+    expect(allSame).toBe(false);
+  });
+
+  it("never returns a hue in the red band [0, 20]", () => {
+    // Test a large set of user_id inputs to confirm no red-band hue appears
+    const testIds = [
+      "user-0",
+      "user-1",
+      "user-2",
+      "user-10",
+      "user-100",
+      "abc",
+      "xyz",
+      "550e8400-e29b-41d4-a716-446655440000",
+      "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "short",
+      "a",
+      "z",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+      "user-with-very-long-id-that-should-still-hash-correctly",
+      "UPPERCASE",
+      "MixedCase123",
+      "test@example.com",
+      "00000000-0000-0000-0000-000000000000",
+    ];
+
+    for (const userId of testIds) {
+      const color = cursorColorForUser(userId);
+      // Parse the hue from "hsl(<h>, 70%, 50%)"
+      const match = /^hsl\((\d+(?:\.\d+)?), 70%, 50%\)$/.exec(color);
+      expect(match, `Expected HSL format for userId "${userId}", got "${color}"`).toBeTruthy();
+      if (match) {
+        const hue = Number(match[1]);
+        expect(hue, `Hue ${hue} for userId "${userId}" is in the red band [0, 20]`).toBeGreaterThan(
+          20,
+        );
+      }
+    }
+  });
+
+  it("returns an HSL string with the correct format", () => {
+    const color = cursorColorForUser("test-user-id");
+    expect(color).toMatch(/^hsl\(\d+, 70%, 50%\)$/);
+  });
+
+  it("works for empty string input (edge case)", () => {
+    // Should not throw; deterministic
+    const color1 = cursorColorForUser("");
+    const color2 = cursorColorForUser("");
+    expect(color1).toBe(color2);
+    expect(color1).toMatch(/^hsl\(\d+, 70%, 50%\)$/);
+  });
+});

--- a/tests/unit/outbox-wiring.test.tsx
+++ b/tests/unit/outbox-wiring.test.tsx
@@ -1,0 +1,284 @@
+// @ts-expect-error vitest is wired in epic 15
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for lib/realtime/wrapped-actions.ts
+ *
+ * Proves that each of the four call sites routes through withOutbox with the
+ * correct OutboxActionId. The wrapped constants are imported directly from the
+ * factored module so we don't need to render any component.
+ *
+ * Strategy:
+ *   - Mock the four server actions so we can track invocations.
+ *   - Mock useBoardStore.getState() to control connection state.
+ *   - Mock enqueueOutbox so we can assert args without real store side-effects.
+ *   - With connection='offline': assert action NOT called; enqueueOutbox IS called.
+ *   - With connection='connected': assert action IS called.
+ *
+ * All describe blocks are .skip per repo convention — vitest is enabled in epic 15.
+ */
+
+// ---- Mock sonner -----------------------------------------------------------
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), {
+    error: vi.fn(),
+    success: vi.fn(),
+  }),
+}));
+
+// ---- Mock the cells actions module -----------------------------------------
+vi.mock("../../app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions", () => ({
+  setCellValue: vi.fn(),
+  bulkSetCellValue: vi.fn(),
+}));
+
+// ---- Mock the tasks actions module -----------------------------------------
+vi.mock("../../app/(app)/w/[workspaceSlug]/b/[boardId]/tasks/actions", () => ({
+  renameTask: vi.fn(),
+  moveTask: vi.fn(),
+  bulkDeleteTasks: vi.fn(),
+  bulkDuplicateTasks: vi.fn(),
+  bulkMoveTasksToGroup: vi.fn(),
+}));
+
+// ---- Mock the groups actions module ----------------------------------------
+vi.mock("../../app/(app)/w/[workspaceSlug]/b/[boardId]/groups/actions", () => ({
+  renameGroup: vi.fn(),
+  reorderGroup: vi.fn(),
+}));
+
+// ---- Mock board store -------------------------------------------------------
+const mockEnqueueOutbox = vi.fn();
+const mockState = {
+  connection: "connected" as "connected" | "offline" | "reconnecting",
+  outboxOverflow: false,
+  outbox: [] as Array<{
+    id: string;
+    actionId: string;
+    args: unknown[];
+    optimisticUpdatedAt: number;
+    enqueuedAt: number;
+  }>,
+  enqueueOutbox: mockEnqueueOutbox,
+  dequeueOutbox: vi.fn(),
+};
+
+vi.mock("../../stores/board-store", () => ({
+  useBoardStore: {
+    getState: () => mockState,
+    setState: (patch: Partial<typeof mockState>) => {
+      Object.assign(mockState, patch);
+    },
+  },
+}));
+
+// ---- Import mocked modules (after vi.mock calls) ---------------------------
+// Dynamic import ensures vi.mock hoisting is in effect before the module loads.
+
+type WrappedActionsModule = typeof import("../../lib/realtime/wrapped-actions");
+type CellActionsModule =
+  typeof import("../../app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions");
+type TaskActionsModule =
+  typeof import("../../app/(app)/w/[workspaceSlug]/b/[boardId]/tasks/actions");
+type GroupActionsModule =
+  typeof import("../../app/(app)/w/[workspaceSlug]/b/[boardId]/groups/actions");
+
+async function getWrapped(): Promise<WrappedActionsModule> {
+  return import("../../lib/realtime/wrapped-actions");
+}
+async function getCellActions(): Promise<CellActionsModule> {
+  return import("../../app/(app)/w/[workspaceSlug]/b/[boardId]/cells/actions");
+}
+async function getTaskActions(): Promise<TaskActionsModule> {
+  return import("../../app/(app)/w/[workspaceSlug]/b/[boardId]/tasks/actions");
+}
+async function getGroupActions(): Promise<GroupActionsModule> {
+  return import("../../app/(app)/w/[workspaceSlug]/b/[boardId]/groups/actions");
+}
+
+// ---- Helpers ---------------------------------------------------------------
+
+function setOffline() {
+  mockState.connection = "offline";
+}
+
+function setConnected() {
+  mockState.connection = "connected";
+  // navigator.onLine defaults to true in jsdom — no override needed
+}
+
+function resetState() {
+  mockState.connection = "connected";
+  mockState.outboxOverflow = false;
+  mockState.outbox = [];
+}
+
+// ---- Tests -----------------------------------------------------------------
+
+describe.skip("wrappedSetCellValue (CellEditor call site)", () => {
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+  });
+
+  it("enqueues with actionId='setCellValue' when offline; does NOT call setCellValue", async () => {
+    const { wrappedSetCellValue } = await getWrapped();
+    const { setCellValue } = await getCellActions();
+
+    setOffline();
+    const args = { taskId: "task-1", columnId: "col-1", value: "hello" };
+    const result = await wrappedSetCellValue(args);
+
+    expect(result).toEqual({ queued: true });
+    expect(setCellValue).not.toHaveBeenCalled();
+    expect(mockEnqueueOutbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "setCellValue",
+        args: [args],
+      }),
+    );
+  });
+
+  it("calls setCellValue directly when connected; does NOT enqueue", async () => {
+    const { wrappedSetCellValue } = await getWrapped();
+    const { setCellValue } = await getCellActions();
+
+    setConnected();
+    const mockResult = { ok: true, data: { task_id: "task-1", column_id: "col-1" } };
+    // @ts-expect-error vi.fn() mock
+    setCellValue.mockResolvedValue(mockResult);
+
+    const args = { taskId: "task-1", columnId: "col-1", value: "hello" };
+    const result = await wrappedSetCellValue(args);
+
+    expect(result).toEqual(mockResult);
+    expect(setCellValue).toHaveBeenCalledWith(args);
+    expect(mockEnqueueOutbox).not.toHaveBeenCalled();
+  });
+});
+
+describe.skip("wrappedRenameTask (TaskTitleCell call site)", () => {
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+  });
+
+  it("enqueues with actionId='renameTask' when offline; does NOT call renameTask", async () => {
+    const { wrappedRenameTask } = await getWrapped();
+    const { renameTask } = await getTaskActions();
+
+    setOffline();
+    const args = { taskId: "task-2", title: "New Title" };
+    const result = await wrappedRenameTask(args);
+
+    expect(result).toEqual({ queued: true });
+    expect(renameTask).not.toHaveBeenCalled();
+    expect(mockEnqueueOutbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "renameTask",
+        args: [args],
+      }),
+    );
+  });
+
+  it("calls renameTask directly when connected; does NOT enqueue", async () => {
+    const { wrappedRenameTask } = await getWrapped();
+    const { renameTask } = await getTaskActions();
+
+    setConnected();
+    const mockResult = { ok: true, data: { id: "task-2", title: "New Title" } };
+    // @ts-expect-error vi.fn() mock
+    renameTask.mockResolvedValue(mockResult);
+
+    const args = { taskId: "task-2", title: "New Title" };
+    const result = await wrappedRenameTask(args);
+
+    expect(result).toEqual(mockResult);
+    expect(renameTask).toHaveBeenCalledWith(args);
+    expect(mockEnqueueOutbox).not.toHaveBeenCalled();
+  });
+});
+
+describe.skip("wrappedRenameGroup (BoardTable/GroupHeaderRow call site)", () => {
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+  });
+
+  it("enqueues with actionId='renameGroup' when offline; does NOT call renameGroup", async () => {
+    const { wrappedRenameGroup } = await getWrapped();
+    const { renameGroup } = await getGroupActions();
+
+    setOffline();
+    const args = { groupId: "group-1", name: "Renamed Group" };
+    const result = await wrappedRenameGroup(args);
+
+    expect(result).toEqual({ queued: true });
+    expect(renameGroup).not.toHaveBeenCalled();
+    expect(mockEnqueueOutbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "renameGroup",
+        args: [args],
+      }),
+    );
+  });
+
+  it("calls renameGroup directly when connected; does NOT enqueue", async () => {
+    const { wrappedRenameGroup } = await getWrapped();
+    const { renameGroup } = await getGroupActions();
+
+    setConnected();
+    const mockResult = { ok: true, data: { id: "group-1", name: "Renamed Group" } };
+    // @ts-expect-error vi.fn() mock
+    renameGroup.mockResolvedValue(mockResult);
+
+    const args = { groupId: "group-1", name: "Renamed Group" };
+    const result = await wrappedRenameGroup(args);
+
+    expect(result).toEqual(mockResult);
+    expect(renameGroup).toHaveBeenCalledWith(args);
+    expect(mockEnqueueOutbox).not.toHaveBeenCalled();
+  });
+});
+
+describe.skip("wrappedBulkSetCellValue (BulkActionBar call site)", () => {
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+  });
+
+  it("enqueues with actionId='bulkSetCellValue' when offline; does NOT call bulkSetCellValue", async () => {
+    const { wrappedBulkSetCellValue } = await getWrapped();
+    const { bulkSetCellValue } = await getCellActions();
+
+    setOffline();
+    const args = { taskIds: ["task-1", "task-2"], columnId: "col-1", value: "done" };
+    const result = await wrappedBulkSetCellValue(args);
+
+    expect(result).toEqual({ queued: true });
+    expect(bulkSetCellValue).not.toHaveBeenCalled();
+    expect(mockEnqueueOutbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "bulkSetCellValue",
+        args: [args],
+      }),
+    );
+  });
+
+  it("calls bulkSetCellValue directly when connected; does NOT enqueue", async () => {
+    const { wrappedBulkSetCellValue } = await getWrapped();
+    const { bulkSetCellValue } = await getCellActions();
+
+    setConnected();
+    const mockResult = { ok: true, data: { cells: [] } };
+    // @ts-expect-error vi.fn() mock
+    bulkSetCellValue.mockResolvedValue(mockResult);
+
+    const args = { taskIds: ["task-1", "task-2"], columnId: "col-1", value: "done" };
+    const result = await wrappedBulkSetCellValue(args);
+
+    expect(result).toEqual(mockResult);
+    expect(bulkSetCellValue).toHaveBeenCalledWith(args);
+    expect(mockEnqueueOutbox).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/outbox.test.ts
+++ b/tests/unit/outbox.test.ts
@@ -1,0 +1,408 @@
+// @ts-expect-error vitest is wired in epic 15
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for lib/realtime/outbox.ts
+ *
+ * Strategy: mock `useBoardStore` and `outboxRegistry` so tests are
+ * pure unit tests with no real Supabase or localStorage.
+ *
+ * Mocking the `sonner` toast import so toast calls are recorded but
+ * don't throw or emit side effects.
+ */
+
+// ---- Mock sonner -------------------------------------------------------
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), {
+    error: vi.fn(),
+    success: vi.fn(),
+  }),
+}));
+
+// ---- Mock the outbox registry ------------------------------------------
+vi.mock("../../lib/realtime/outbox-registry", () => ({
+  outboxRegistry: {},
+}));
+
+// ---- Mock the board store ----------------------------------------------
+// We use a simple in-memory state object that the tests can manipulate.
+const mockState: {
+  connection: string;
+  outbox: Array<{
+    id: string;
+    actionId: string;
+    args: unknown[];
+    optimisticUpdatedAt: number;
+    enqueuedAt: number;
+  }>;
+  outboxOverflow: boolean;
+  enqueueOutbox: (entry: Omit<(typeof mockState.outbox)[number], "id" | "enqueuedAt">) => void;
+  dequeueOutbox: (id: string) => void;
+  clearOutbox: () => void;
+} = {
+  connection: "connected",
+  outbox: [],
+  outboxOverflow: false,
+  enqueueOutbox(entry) {
+    mockState.outbox.push({
+      ...entry,
+      id: `mock-id-${mockState.outbox.length}`,
+      enqueuedAt: Date.now(),
+    });
+  },
+  dequeueOutbox(id) {
+    mockState.outbox = mockState.outbox.filter((e) => e.id !== id);
+  },
+  clearOutbox() {
+    mockState.outbox = [];
+  },
+};
+
+vi.mock("../../stores/board-store", () => ({
+  useBoardStore: {
+    getState: () => mockState,
+    setState: (patch: Partial<typeof mockState>) => {
+      Object.assign(mockState, patch);
+    },
+  },
+}));
+
+// ---- Import SUT AFTER mocks are in place --------------------------------
+// Dynamic import is used in individual tests so vi.mock hoisting takes effect.
+type OutboxModule = typeof import("../../lib/realtime/outbox");
+type OutboxRegistryModule = typeof import("../../lib/realtime/outbox-registry");
+
+async function getOutbox(): Promise<OutboxModule> {
+  return import("../../lib/realtime/outbox");
+}
+
+async function getRegistry(): Promise<OutboxRegistryModule> {
+  return import("../../lib/realtime/outbox-registry");
+}
+
+// ---- Helper to reset shared state between tests -------------------------
+function resetMockState() {
+  mockState.connection = "connected";
+  mockState.outbox = [];
+  mockState.outboxOverflow = false;
+}
+
+// ---- Tests --------------------------------------------------------------
+
+describe.skip("isOnline", () => {
+  it("returns true on the server (navigator not defined)", async () => {
+    const { isOnline } = await getOutbox();
+    // In the test environment, navigator is typically available, but
+    // we can verify the function doesn't throw and returns a boolean.
+    const result = isOnline();
+    expect(typeof result).toBe("boolean");
+  });
+
+  it("returns navigator.onLine when available", async () => {
+    const { isOnline } = await getOutbox();
+    // In jsdom / Node test environment, navigator.onLine defaults to true
+    expect(isOnline()).toBe(true);
+  });
+});
+
+describe.skip("withOutbox", () => {
+  beforeEach(() => {
+    resetMockState();
+    vi.clearAllMocks();
+  });
+
+  it("enqueues when store connection is 'offline' and returns { queued: true }", async () => {
+    const { withOutbox } = await getOutbox();
+    mockState.connection = "offline";
+
+    const mockAction = vi.fn().mockResolvedValue("result");
+    const wrapped = withOutbox("setCellValue", mockAction);
+
+    const result = await wrapped("arg1", "arg2");
+
+    expect(result).toEqual({ queued: true });
+    expect(mockAction).not.toHaveBeenCalled();
+    expect(mockState.outbox).toHaveLength(1);
+    expect(mockState.outbox[0]).toMatchObject({
+      actionId: "setCellValue",
+      args: ["arg1", "arg2"],
+    });
+  });
+
+  it("enqueues when navigator.onLine is false and returns { queued: true }", async () => {
+    const { withOutbox } = await getOutbox();
+    // Override navigator.onLine to false
+    const origDescriptor = Object.getOwnPropertyDescriptor(navigator, "onLine");
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      get: () => false,
+    });
+
+    try {
+      const mockAction = vi.fn().mockResolvedValue("result");
+      const wrapped = withOutbox("renameGroup", mockAction);
+
+      const result = await wrapped("groupId", "New Name");
+
+      expect(result).toEqual({ queued: true });
+      expect(mockAction).not.toHaveBeenCalled();
+      expect(mockState.outbox).toHaveLength(1);
+      expect(mockState.outbox[0]).toMatchObject({
+        actionId: "renameGroup",
+        args: ["groupId", "New Name"],
+      });
+    } finally {
+      // Restore navigator.onLine
+      if (origDescriptor) {
+        Object.defineProperty(navigator, "onLine", origDescriptor);
+      } else {
+        Object.defineProperty(navigator, "onLine", {
+          configurable: true,
+          get: () => true,
+        });
+      }
+    }
+  });
+
+  it("invokes the action when online and returns the result", async () => {
+    const { withOutbox } = await getOutbox();
+    mockState.connection = "connected";
+
+    const mockAction = vi.fn().mockResolvedValue({ success: true });
+    const wrapped = withOutbox("setCellValue", mockAction);
+
+    const result = await wrapped("arg1");
+
+    expect(result).toEqual({ success: true });
+    expect(mockAction).toHaveBeenCalledWith("arg1");
+    expect(mockState.outbox).toHaveLength(0);
+  });
+
+  it("enqueues and returns { queued: true } when action throws a network error", async () => {
+    const { withOutbox } = await getOutbox();
+    mockState.connection = "connected";
+
+    const networkError = new TypeError("Failed to fetch");
+    const mockAction = vi.fn().mockRejectedValue(networkError);
+    const wrapped = withOutbox("setCellValue", mockAction);
+
+    const result = await wrapped("arg1");
+
+    expect(result).toEqual({ queued: true });
+    expect(mockState.outbox).toHaveLength(1);
+    expect(mockState.outbox[0]).toMatchObject({
+      actionId: "setCellValue",
+      args: ["arg1"],
+    });
+  });
+
+  it("enqueues and returns { queued: true } when action throws error matching /network/i", async () => {
+    const { withOutbox } = await getOutbox();
+    mockState.connection = "connected";
+
+    const networkError = new Error("Network timeout occurred");
+    const mockAction = vi.fn().mockRejectedValue(networkError);
+    const wrapped = withOutbox("renameTask", mockAction);
+
+    const result = await wrapped("taskId", "Title");
+
+    expect(result).toEqual({ queued: true });
+    expect(mockState.outbox).toHaveLength(1);
+  });
+
+  it("re-throws when action throws a validation error (non-network)", async () => {
+    const { withOutbox } = await getOutbox();
+    mockState.connection = "connected";
+
+    const validationError = new Error("Validation failed: title is required");
+    const mockAction = vi.fn().mockRejectedValue(validationError);
+    const wrapped = withOutbox("renameTask", mockAction);
+
+    await expect(wrapped("taskId", "")).rejects.toThrow("Validation failed");
+    expect(mockState.outbox).toHaveLength(0);
+  });
+
+  it("re-throws when action throws an auth error (non-network)", async () => {
+    const { withOutbox } = await getOutbox();
+    mockState.connection = "connected";
+
+    const authError = { code: "UNAUTHORIZED", message: "Not a board member" };
+    const mockAction = vi.fn().mockRejectedValue(authError);
+    const wrapped = withOutbox("setCellValue", mockAction);
+
+    await expect(wrapped("arg1")).rejects.toEqual(authError);
+    expect(mockState.outbox).toHaveLength(0);
+  });
+
+  it("refuses to enqueue when outboxOverflow is true; throws", async () => {
+    const { withOutbox } = await getOutbox();
+    const { toast } = await import("sonner");
+    mockState.connection = "offline";
+    mockState.outboxOverflow = true;
+
+    const mockAction = vi.fn().mockResolvedValue("result");
+    const wrapped = withOutbox("setCellValue", mockAction);
+
+    await expect(wrapped("arg1")).rejects.toThrow("Outbox overflow");
+    expect(mockState.outbox).toHaveLength(0);
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("Offline queue is full"));
+  });
+});
+
+describe.skip("flushOutbox", () => {
+  beforeEach(() => {
+    resetMockState();
+    vi.clearAllMocks();
+  });
+
+  it("replays entries in submission order (ascending enqueuedAt)", async () => {
+    const { flushOutbox } = await getOutbox();
+    const registry = await getRegistry();
+
+    const callOrder: string[] = [];
+    const action1 = vi.fn().mockImplementation(async () => {
+      callOrder.push("action1");
+    });
+    const action2 = vi.fn().mockImplementation(async () => {
+      callOrder.push("action2");
+    });
+    const action3 = vi.fn().mockImplementation(async () => {
+      callOrder.push("action3");
+    });
+
+    // Manually populate the registry
+    (registry.outboxRegistry as Record<string, unknown>).setCellValue = action1;
+    (registry.outboxRegistry as Record<string, unknown>).renameGroup = action2;
+    (registry.outboxRegistry as Record<string, unknown>).renameTask = action3;
+
+    // Seed outbox entries with different enqueuedAt values (out of insertion order)
+    mockState.outbox = [
+      {
+        id: "id-2",
+        actionId: "renameGroup",
+        args: ["g1", "New Name"],
+        optimisticUpdatedAt: 1000,
+        enqueuedAt: 200,
+      },
+      {
+        id: "id-1",
+        actionId: "setCellValue",
+        args: ["v1"],
+        optimisticUpdatedAt: 1000,
+        enqueuedAt: 100,
+      },
+      {
+        id: "id-3",
+        actionId: "renameTask",
+        args: ["t1", "Title"],
+        optimisticUpdatedAt: 1000,
+        enqueuedAt: 300,
+      },
+    ];
+
+    const result = await flushOutbox();
+
+    // Should have been called in enqueuedAt order: id-1, id-2, id-3
+    expect(callOrder).toEqual(["action1", "action2", "action3"]);
+    expect(result).toEqual({ flushed: 3, dropped: 0 });
+  });
+
+  it("drops an entry whose action throws; toasts; continues with next", async () => {
+    const { flushOutbox } = await getOutbox();
+    const registry = await getRegistry();
+    const { toast } = await import("sonner");
+
+    const failAction = vi.fn().mockRejectedValue(new Error("DB error"));
+    const successAction = vi.fn().mockResolvedValue("ok");
+
+    (registry.outboxRegistry as Record<string, unknown>).setCellValue = failAction;
+    (registry.outboxRegistry as Record<string, unknown>).renameTask = successAction;
+
+    mockState.outbox = [
+      {
+        id: "id-fail",
+        actionId: "setCellValue",
+        args: [],
+        optimisticUpdatedAt: 1000,
+        enqueuedAt: 100,
+      },
+      {
+        id: "id-ok",
+        actionId: "renameTask",
+        args: [],
+        optimisticUpdatedAt: 1000,
+        enqueuedAt: 200,
+      },
+    ];
+
+    const result = await flushOutbox();
+
+    expect(result).toEqual({ flushed: 1, dropped: 1 });
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("DB error"));
+    // Both entries should be dequeued (success + failure are both removed)
+    expect(mockState.outbox).toHaveLength(0);
+  });
+
+  it("returns correct { flushed, dropped } counts", async () => {
+    const { flushOutbox } = await getOutbox();
+    const registry = await getRegistry();
+
+    const okAction = vi.fn().mockResolvedValue("ok");
+    (registry.outboxRegistry as Record<string, unknown>).setCellValue = okAction;
+    (registry.outboxRegistry as Record<string, unknown>).renameGroup = okAction;
+    (registry.outboxRegistry as Record<string, unknown>).renameTask = vi
+      .fn()
+      .mockRejectedValue(new Error("fail"));
+
+    mockState.outbox = [
+      { id: "a", actionId: "setCellValue", args: [], optimisticUpdatedAt: 0, enqueuedAt: 1 },
+      { id: "b", actionId: "renameGroup", args: [], optimisticUpdatedAt: 0, enqueuedAt: 2 },
+      { id: "c", actionId: "renameTask", args: [], optimisticUpdatedAt: 0, enqueuedAt: 3 },
+    ];
+
+    const result = await flushOutbox();
+    expect(result).toEqual({ flushed: 2, dropped: 1 });
+  });
+
+  it("resets outboxOverflow to false on flush", async () => {
+    const { flushOutbox } = await getOutbox();
+    mockState.outbox = [];
+    mockState.outboxOverflow = true;
+
+    await flushOutbox();
+
+    expect(mockState.outboxOverflow).toBe(false);
+  });
+
+  it("returns { flushed: 0, dropped: 0 } when outbox is empty", async () => {
+    const { flushOutbox } = await getOutbox();
+    mockState.outbox = [];
+
+    const result = await flushOutbox();
+    expect(result).toEqual({ flushed: 0, dropped: 0 });
+  });
+
+  it("drops entries with unknown actionId; toasts", async () => {
+    const { flushOutbox } = await getOutbox();
+    const { toast } = await import("sonner");
+    const registry = await getRegistry();
+
+    // Remove unknown action from registry
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete (registry.outboxRegistry as Record<string, unknown>).unknownAction;
+
+    mockState.outbox = [
+      {
+        id: "bad",
+        actionId: "unknownAction",
+        args: [],
+        optimisticUpdatedAt: 0,
+        enqueuedAt: 1,
+      },
+    ];
+
+    const result = await flushOutbox();
+    expect(result).toEqual({ flushed: 0, dropped: 1 });
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("unknown action"));
+  });
+});

--- a/tests/unit/realtime-throttle.test.ts
+++ b/tests/unit/realtime-throttle.test.ts
@@ -1,0 +1,105 @@
+// @ts-expect-error vitest is wired in epic 15
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { throttle } from "../../lib/realtime/throttle";
+
+describe.skip("throttle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires the leading call synchronously (immediately on first invocation)", () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled("a");
+
+    // Leading edge fires immediately
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("a");
+  });
+
+  it("coalesces repeated calls within the wait window; trailing fires once with last args", () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 100);
+
+    // Leading call
+    throttled("first");
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Rapid calls within the 100ms window
+    throttled("second");
+    throttled("third");
+    throttled("fourth");
+
+    // Still only the leading call has fired
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Advance past the wait window — trailing call fires with last args
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith("fourth");
+  });
+
+  it("allows a new leading call after the window has passed", () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled("first");
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Advance fully past the window with no more calls (no trailing scheduled)
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1); // no trailing call (nothing was queued)
+
+    // New call after window resets — fires as leading edge
+    throttled("second");
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith("second");
+  });
+
+  it("cancel() prevents the trailing call from firing", () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 100);
+
+    // Leading call
+    throttled("first");
+    // Queue a trailing call
+    throttled("second");
+
+    // Cancel before the trailing fires
+    throttled.cancel();
+
+    vi.advanceTimersByTime(200);
+
+    // Only the leading call; trailing was cancelled
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("first");
+  });
+
+  it("passes multiple arguments correctly", () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled("a", "b", "c");
+    expect(fn).toHaveBeenCalledWith("a", "b", "c");
+  });
+
+  it("trailing call uses the last-args from the window, not earlier ones", () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled("alpha"); // leading
+    throttled("beta"); // queued — will be overwritten
+    throttled("gamma"); // overwrites beta as latest trailing args
+
+    vi.advanceTimersByTime(100);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith("gamma");
+  });
+});

--- a/tests/unit/use-board-realtime.test.ts
+++ b/tests/unit/use-board-realtime.test.ts
@@ -1,0 +1,465 @@
+// @ts-expect-error vitest is wired in epic 15
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock next/navigation before importing the hook
+// ---------------------------------------------------------------------------
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+// ---------------------------------------------------------------------------
+// Build a realistic stub channel that the hook can drive
+// ---------------------------------------------------------------------------
+
+type EventHandler = (payload: unknown) => void;
+
+interface RegisteredEvent {
+  type: string;
+  opts: Record<string, unknown>;
+  handler: EventHandler;
+}
+
+interface StubChannel {
+  on: ReturnType<typeof vi.fn>;
+  subscribe: ReturnType<typeof vi.fn>;
+  track: ReturnType<typeof vi.fn>;
+  unsubscribe: ReturnType<typeof vi.fn>;
+  presenceState: ReturnType<typeof vi.fn>;
+  _triggerStatus: (status: string) => Promise<void>;
+  _triggerEvent: (type: string, event: string, payload: unknown) => void;
+  _registeredEvents: RegisteredEvent[];
+  _findSub: (table: string) => RegisteredEvent;
+}
+
+function makeStubChannel(): StubChannel {
+  const registeredEvents: RegisteredEvent[] = [];
+  let subscribeCallback: ((status: string) => Promise<void>) | null = null;
+
+  const channel: StubChannel = {
+    _registeredEvents: registeredEvents,
+    on: vi.fn((type: string, opts: Record<string, unknown>, handler: EventHandler) => {
+      registeredEvents.push({ type, opts, handler });
+      return channel;
+    }),
+    subscribe: vi.fn((cb: (status: string) => Promise<void>) => {
+      subscribeCallback = cb;
+      return channel;
+    }),
+    track: vi.fn(() => Promise.resolve()),
+    unsubscribe: vi.fn(() => Promise.resolve()),
+    presenceState: vi.fn(() => ({
+      "user-2": [{ user_id: "user-2", online_at: Date.now(), viewing: { type: "board" } }],
+    })),
+    _triggerStatus: async (status: string) => {
+      if (subscribeCallback) {
+        await subscribeCallback(status);
+      }
+    },
+    _triggerEvent: (type: string, event: string, payload: unknown) => {
+      for (const reg of registeredEvents) {
+        if (reg.type === type && (reg.opts as { event?: string }).event === event) {
+          reg.handler(payload);
+        }
+      }
+    },
+    /** Finds a postgres_changes registration for a given table; throws if absent. */
+    _findSub: (table: string): RegisteredEvent => {
+      const sub = registeredEvents.find(
+        (e) => e.type === "postgres_changes" && (e.opts as { table?: string }).table === table,
+      );
+      if (!sub) {
+        throw new Error(`No postgres_changes subscription found for table: ${table}`);
+      }
+      return sub;
+    },
+  };
+
+  return channel;
+}
+
+// ---------------------------------------------------------------------------
+// Mock lib/supabase/client
+// ---------------------------------------------------------------------------
+
+let stubChannel: StubChannel;
+const mockRemoveChannel = vi.fn(() => Promise.resolve());
+
+vi.mock("../../lib/supabase/client", () => ({
+  createClient: () => ({
+    channel: () => stubChannel,
+    removeChannel: mockRemoveChannel,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the board store actions
+// ---------------------------------------------------------------------------
+
+const mockStore = {
+  setConnectionStatus: vi.fn(),
+  setPresence: vi.fn(),
+  setCursor: vi.fn(),
+  setTyping: vi.fn(),
+  applyTaskUpsert: vi.fn(),
+  applyTaskDelete: vi.fn(),
+  applyGroupUpsert: vi.fn(),
+  applyGroupDelete: vi.fn(),
+  applyColumnUpsert: vi.fn(),
+  applyColumnDelete: vi.fn(),
+  applyCellUpsert: vi.fn(),
+  pruneExpiredCursors: vi.fn(),
+  pruneExpiredTyping: vi.fn(),
+};
+
+vi.mock("../../stores/board-store", () => ({
+  useBoardStore: {
+    getState: () => mockStore,
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import the hook AFTER mocks are set up
+// ---------------------------------------------------------------------------
+// @ts-expect-error renderHook is wired in epic 15
+import { act, renderHook } from "@testing-library/react";
+import { useBoardRealtime } from "../../hooks/use-board-realtime";
+
+const BOARD_ID = "board-abc";
+const USER_ID = "user-123";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clearAllMocks(): void {
+  mockRefresh.mockClear();
+  mockRemoveChannel.mockClear();
+  for (const fn of Object.values(mockStore)) {
+    (fn as ReturnType<typeof vi.fn>).mockClear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe.skip("useBoardRealtime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stubChannel = makeStubChannel();
+    clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // Channel registration — postgres_changes subscriptions
+  // -------------------------------------------------------------------------
+
+  it("registers postgres_changes for task with board_id filter and * event", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    const taskSub = stubChannel._findSub("task");
+    expect((taskSub.opts as { event?: string }).event).toBe("*");
+    expect((taskSub.opts as { filter?: string }).filter).toBe(`board_id=eq.${BOARD_ID}`);
+  });
+
+  it("registers postgres_changes for group with board_id filter", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    const sub = stubChannel._findSub("group");
+    expect((sub.opts as { filter?: string }).filter).toBe(`board_id=eq.${BOARD_ID}`);
+  });
+
+  it("registers postgres_changes for column with board_id filter", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    const sub = stubChannel._findSub("column");
+    expect((sub.opts as { filter?: string }).filter).toBe(`board_id=eq.${BOARD_ID}`);
+  });
+
+  it("registers postgres_changes for cell with board_id filter (enabled after S0)", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    const sub = stubChannel._findSub("cell");
+    expect((sub.opts as { filter?: string }).filter).toBe(`board_id=eq.${BOARD_ID}`);
+  });
+
+  it("does NOT register postgres_changes for comment (deferred to epic 09)", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    const commentSub = stubChannel._registeredEvents.find(
+      (e) => e.type === "postgres_changes" && (e.opts as { table?: string }).table === "comment",
+    );
+    expect(commentSub).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // SUBSCRIBED status — initial connect
+  // -------------------------------------------------------------------------
+
+  it("on SUBSCRIBED: calls setConnectionStatus('connected') and track()", async () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    await act(async () => {
+      await stubChannel._triggerStatus("SUBSCRIBED");
+    });
+
+    expect(mockStore.setConnectionStatus).toHaveBeenCalledWith("connected");
+    expect(stubChannel.track).toHaveBeenCalledWith({
+      user_id: USER_ID,
+      online_at: expect.any(Number),
+      viewing: { type: "board" },
+    });
+  });
+
+  it("on first SUBSCRIBED (no prior reconnect): does NOT call router.refresh()", async () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    await act(async () => {
+      await stubChannel._triggerStatus("SUBSCRIBED");
+    });
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // TIMED_OUT — marks reconnecting
+  // -------------------------------------------------------------------------
+
+  it("on TIMED_OUT: calls setConnectionStatus('reconnecting') and clears presence", async () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    await act(async () => {
+      await stubChannel._triggerStatus("TIMED_OUT");
+    });
+
+    expect(mockStore.setConnectionStatus).toHaveBeenCalledWith("reconnecting");
+    expect(mockStore.setPresence).toHaveBeenCalledWith({});
+  });
+
+  it("on CHANNEL_ERROR: calls setConnectionStatus('reconnecting') and clears presence", async () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    await act(async () => {
+      await stubChannel._triggerStatus("CHANNEL_ERROR");
+    });
+
+    expect(mockStore.setConnectionStatus).toHaveBeenCalledWith("reconnecting");
+    expect(mockStore.setPresence).toHaveBeenCalledWith({});
+  });
+
+  // -------------------------------------------------------------------------
+  // Reconnect transition: TIMED_OUT → SUBSCRIBED
+  // -------------------------------------------------------------------------
+
+  it("on TIMED_OUT → SUBSCRIBED: calls router.refresh() before marking connected", async () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    await act(async () => {
+      await stubChannel._triggerStatus("SUBSCRIBED"); // initial connect
+    });
+    mockRefresh.mockClear();
+    mockStore.setConnectionStatus.mockClear();
+
+    await act(async () => {
+      await stubChannel._triggerStatus("TIMED_OUT"); // disconnect
+    });
+
+    await act(async () => {
+      await stubChannel._triggerStatus("SUBSCRIBED"); // reconnect
+    });
+
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(mockStore.setConnectionStatus).toHaveBeenCalledWith("connected");
+  });
+
+  // -------------------------------------------------------------------------
+  // Presence sync
+  // -------------------------------------------------------------------------
+
+  it("on presence sync: calls setPresence with channel.presenceState()", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    act(() => {
+      stubChannel._triggerEvent("presence", "sync", {});
+    });
+
+    expect(mockStore.setPresence).toHaveBeenCalledWith(
+      expect.objectContaining({ "user-2": expect.any(Array) }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Broadcast — cursor and typing
+  // -------------------------------------------------------------------------
+
+  it("on broadcast cursor: calls setCursor with payload", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    const cursorPayload = { user_id: "user-2", task_id: "t1", column_id: "col-1", at: Date.now() };
+
+    act(() => {
+      stubChannel._triggerEvent("broadcast", "cursor", { payload: cursorPayload });
+    });
+
+    expect(mockStore.setCursor).toHaveBeenCalledWith(cursorPayload);
+  });
+
+  it("on broadcast typing: calls setTyping with payload", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    const typingPayload = { user_id: "user-2", context: "comment:t1", at: Date.now() };
+
+    act(() => {
+      stubChannel._triggerEvent("broadcast", "typing", { payload: typingPayload });
+    });
+
+    expect(mockStore.setTyping).toHaveBeenCalledWith(typingPayload);
+  });
+
+  // -------------------------------------------------------------------------
+  // Postgres changes dispatch
+  // -------------------------------------------------------------------------
+
+  it("task INSERT calls applyTaskUpsert", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    const newTask = { id: "t1", board_id: BOARD_ID, updated_at: "2024-01-01T00:00:00Z" };
+
+    act(() => {
+      const sub = stubChannel._findSub("task");
+      sub.handler({ eventType: "INSERT", new: newTask, old: {} });
+    });
+
+    expect(mockStore.applyTaskUpsert).toHaveBeenCalledWith(newTask);
+  });
+
+  it("task DELETE calls applyTaskDelete with id from e.old", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    act(() => {
+      const sub = stubChannel._findSub("task");
+      sub.handler({ eventType: "DELETE", new: {}, old: { id: "t-deleted" } });
+    });
+
+    expect(mockStore.applyTaskDelete).toHaveBeenCalledWith("t-deleted");
+  });
+
+  it("group DELETE calls applyGroupDelete with id", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    act(() => {
+      const sub = stubChannel._findSub("group");
+      sub.handler({ eventType: "DELETE", new: {}, old: { id: "g-deleted" } });
+    });
+
+    expect(mockStore.applyGroupDelete).toHaveBeenCalledWith("g-deleted");
+  });
+
+  it("column DELETE calls applyColumnDelete with id", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    act(() => {
+      const sub = stubChannel._findSub("column");
+      sub.handler({ eventType: "DELETE", new: {}, old: { id: "c-deleted" } });
+    });
+
+    expect(mockStore.applyColumnDelete).toHaveBeenCalledWith("c-deleted");
+  });
+
+  it("cell INSERT calls applyCellUpsert", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    const newCell = {
+      task_id: "t1",
+      column_id: "col1",
+      board_id: BOARD_ID,
+      updated_at: "2024-01-01T00:00:00Z",
+    };
+
+    act(() => {
+      const sub = stubChannel._findSub("cell");
+      sub.handler({ eventType: "INSERT", new: newCell, old: {} });
+    });
+
+    expect(mockStore.applyCellUpsert).toHaveBeenCalledWith(newCell);
+  });
+
+  it("cell DELETE does not call any store delete method (no store method exists)", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    act(() => {
+      const sub = stubChannel._findSub("cell");
+      sub.handler({ eventType: "DELETE", new: {}, old: { id: "cell-id" } });
+    });
+
+    // No cell-delete store method should be called
+    expect(mockStore.applyTaskDelete).not.toHaveBeenCalled();
+    expect(mockStore.applyGroupDelete).not.toHaveBeenCalled();
+    expect(mockStore.applyColumnDelete).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Sweeper interval
+  // -------------------------------------------------------------------------
+
+  it("sweeper interval calls pruneExpiredCursors and pruneExpiredTyping every 2s", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(mockStore.pruneExpiredCursors).toHaveBeenCalledTimes(1);
+    expect(mockStore.pruneExpiredTyping).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(mockStore.pruneExpiredCursors).toHaveBeenCalledTimes(2);
+    expect(mockStore.pruneExpiredTyping).toHaveBeenCalledTimes(2);
+  });
+
+  it("sweeper calls pruneExpiredCursors and pruneExpiredTyping with ttlMs = 5000", () => {
+    renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(mockStore.pruneExpiredCursors).toHaveBeenCalledWith(expect.any(Number), 5000);
+    expect(mockStore.pruneExpiredTyping).toHaveBeenCalledWith(expect.any(Number), 5000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Cleanup
+  // -------------------------------------------------------------------------
+
+  it("cleanup calls channel.unsubscribe() and removeChannel()", () => {
+    const { unmount } = renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    unmount();
+
+    expect(stubChannel.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(mockRemoveChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleanup clears the sweeper interval (no more prune calls after unmount)", () => {
+    const { unmount } = renderHook(() => useBoardRealtime(BOARD_ID, USER_ID));
+
+    unmount();
+    mockStore.pruneExpiredCursors.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+
+    expect(mockStore.pruneExpiredCursors).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/use-cursor-broadcast.test.ts
+++ b/tests/unit/use-cursor-broadcast.test.ts
@@ -1,0 +1,129 @@
+// @ts-expect-error vitest is wired in epic 15
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock lib/supabase/client before importing the hook
+// ---------------------------------------------------------------------------
+
+interface StubChannel {
+  send: ReturnType<typeof vi.fn>;
+}
+
+let stubChannel: StubChannel;
+
+vi.mock("../../lib/supabase/client", () => ({
+  createClient: () => ({
+    channel: () => stubChannel,
+  }),
+}));
+
+// We also need to make sure lib/realtime/channel resolves without side effects.
+// It is a pure function; no mock needed.
+
+// ---------------------------------------------------------------------------
+// Import hook after mocks are set up
+// ---------------------------------------------------------------------------
+
+// @ts-expect-error vitest is wired in epic 15
+import { renderHook } from "@testing-library/react";
+import { useCursorBroadcast } from "../../hooks/use-cursor-broadcast";
+
+describe.skip("useCursorBroadcast", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stubChannel = {
+      send: vi.fn(),
+    };
+    // Restore visibility to 'visible' (jsdom default)
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("returns an emit function", () => {
+    const { result } = renderHook(() => useCursorBroadcast("board-1", "user-1"));
+    expect(typeof result.current.emit).toBe("function");
+  });
+
+  it("sends to channel with correct payload on emit", () => {
+    const { result } = renderHook(() => useCursorBroadcast("board-1", "user-1"));
+    result.current.emit("task-1", "col-1");
+
+    expect(stubChannel.send).toHaveBeenCalledTimes(1);
+    const call = stubChannel.send.mock.calls[0][0];
+    expect(call.type).toBe("broadcast");
+    expect(call.event).toBe("cursor");
+    expect(call.payload.user_id).toBe("user-1");
+    expect(call.payload.task_id).toBe("task-1");
+    expect(call.payload.column_id).toBe("col-1");
+    expect(typeof call.payload.at).toBe("number");
+  });
+
+  it("throttles rapid calls — leading + at most one trailing within 100ms window", () => {
+    const { result } = renderHook(() => useCursorBroadcast("board-1", "user-1"));
+
+    // Fire 10 rapid calls (all within the 100ms throttle window)
+    for (let i = 0; i < 10; i++) {
+      result.current.emit("task-1", `col-${i}`);
+    }
+
+    // Leading call fires immediately — only 1 send so far
+    expect(stubChannel.send).toHaveBeenCalledTimes(1);
+
+    // Advance past the throttle window — trailing call fires (with last args)
+    vi.advanceTimersByTime(110);
+    // Leading + trailing = 2 total
+    expect(stubChannel.send.mock.calls.length).toBeLessThanOrEqual(2);
+    expect(stubChannel.send.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("suppresses emit when document.visibilityState is not 'visible'", () => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    });
+
+    const { result } = renderHook(() => useCursorBroadcast("board-1", "user-1"));
+    result.current.emit("task-1", "col-1");
+
+    // Advance past throttle window to trigger trailing if any
+    vi.advanceTimersByTime(200);
+
+    // No send calls because visibility is hidden
+    expect(stubChannel.send).toHaveBeenCalledTimes(0);
+  });
+
+  it("calls cancel on the throttled emitter on unmount (no trailing after unmount)", () => {
+    const { result, unmount } = renderHook(() => useCursorBroadcast("board-1", "user-1"));
+
+    // Leading call
+    result.current.emit("task-1", "col-1");
+    expect(stubChannel.send).toHaveBeenCalledTimes(1);
+
+    // Queue a trailing call
+    result.current.emit("task-1", "col-2");
+
+    // Unmount before trailing fires — cancel should suppress it
+    unmount();
+
+    vi.advanceTimersByTime(200);
+
+    // Only the leading call; trailing was cancelled on unmount
+    expect(stubChannel.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls channel.send once on first emit (confirms channel is obtained)", () => {
+    // We verify indirectly: after emit, send is called on the stub channel
+    // that was returned. The mock always returns the same stubChannel regardless
+    // of topic; the channel name routing is tested at integration level.
+    const { result } = renderHook(() => useCursorBroadcast("board-42", "user-99"));
+    result.current.emit("task-X", "col-Y");
+    expect(stubChannel.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/use-typing-broadcast.test.ts
+++ b/tests/unit/use-typing-broadcast.test.ts
@@ -227,14 +227,20 @@ describe.skip("useTypingBroadcast", () => {
     expect(stubChannel.send).toHaveBeenCalledTimes(1);
   });
 
-  it("unmount calls channel.unsubscribe() and supabase.removeChannel()", () => {
+  it("unmount does NOT call channel.unsubscribe() or supabase.removeChannel() — board channel is owned by useBoardRealtime", () => {
     const { unmount } = renderHook(() =>
       useTypingBroadcast({ boardId: BOARD_ID, userId: USER_ID, context: CONTEXT }),
     );
 
     unmount();
 
-    expect(stubChannel.unsubscribe).toHaveBeenCalledTimes(1);
-    expect(mockRemoveChannel).toHaveBeenCalledTimes(1);
+    expect(stubChannel.unsubscribe).toHaveBeenCalledTimes(0);
+    expect(mockRemoveChannel).toHaveBeenCalledTimes(0);
+  });
+
+  it("hook does NOT call channel.subscribe() on mount — useBoardRealtime owns the subscription", () => {
+    renderHook(() => useTypingBroadcast({ boardId: BOARD_ID, userId: USER_ID, context: CONTEXT }));
+
+    expect(stubChannel.subscribe).toHaveBeenCalledTimes(0);
   });
 });

--- a/tests/unit/use-typing-broadcast.test.ts
+++ b/tests/unit/use-typing-broadcast.test.ts
@@ -1,0 +1,240 @@
+// @ts-expect-error vitest is wired in epic 15
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Stub channel returned by createClient().channel()
+// ---------------------------------------------------------------------------
+
+interface StubChannel {
+  send: ReturnType<typeof vi.fn>;
+  subscribe: ReturnType<typeof vi.fn>;
+  unsubscribe: ReturnType<typeof vi.fn>;
+}
+
+function makeStubChannel(): StubChannel {
+  return {
+    send: vi.fn(() => Promise.resolve("ok")),
+    subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
+    unsubscribe: vi.fn(() => Promise.resolve()),
+  };
+}
+
+let stubChannel: StubChannel;
+const mockRemoveChannel = vi.fn(() => Promise.resolve());
+
+vi.mock("../../lib/supabase/client", () => ({
+  createClient: () => ({
+    channel: () => stubChannel,
+    removeChannel: mockRemoveChannel,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import the hook AFTER mocks
+// ---------------------------------------------------------------------------
+// @ts-expect-error renderHook is wired in epic 15
+import { act, renderHook } from "@testing-library/react";
+import { useTypingBroadcast } from "../../hooks/use-typing-broadcast";
+
+const BOARD_ID = "board-abc";
+const USER_ID = "user-123";
+const CONTEXT = "comment:task-42";
+
+describe.skip("useTypingBroadcast", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stubChannel = makeStubChannel();
+    mockRemoveChannel.mockClear();
+
+    // Default: tab is visible
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // Throttle: leading edge fires immediately; subsequent calls within 2000ms
+  // are collapsed into one trailing call
+  // -------------------------------------------------------------------------
+
+  it("emit() sends a broadcast payload immediately on first call (leading edge)", () => {
+    const { result } = renderHook(() =>
+      useTypingBroadcast({ boardId: BOARD_ID, userId: USER_ID, context: CONTEXT }),
+    );
+
+    act(() => {
+      result.current.emit();
+    });
+
+    expect(stubChannel.send).toHaveBeenCalledTimes(1);
+    expect(stubChannel.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "broadcast",
+        event: "typing",
+        payload: expect.objectContaining({
+          user_id: USER_ID,
+          context: CONTEXT,
+          at: expect.any(Number),
+        }),
+      }),
+    );
+  });
+
+  it("multiple emit() calls within 2000ms result in at most two sends (leading + one trailing)", () => {
+    const { result } = renderHook(() =>
+      useTypingBroadcast({ boardId: BOARD_ID, userId: USER_ID, context: CONTEXT }),
+    );
+
+    act(() => {
+      result.current.emit(); // leading
+      result.current.emit(); // within window — queued
+      result.current.emit(); // within window — replaces queued
+    });
+
+    // Only the leading call has fired so far
+    expect(stubChannel.send).toHaveBeenCalledTimes(1);
+
+    // Advance past the 2000ms throttle window — trailing fires
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(stubChannel.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("a second emit() after 2000ms fires as a fresh leading call (window has reset)", () => {
+    const { result } = renderHook(() =>
+      useTypingBroadcast({ boardId: BOARD_ID, userId: USER_ID, context: CONTEXT }),
+    );
+
+    act(() => {
+      result.current.emit(); // first leading
+    });
+    expect(stubChannel.send).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(2000); // window resets, no trailing queued
+    });
+
+    act(() => {
+      result.current.emit(); // second leading
+    });
+    expect(stubChannel.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("payload shape satisfies TypingPayload: user_id, context, at (epoch ms)", () => {
+    const now = 1_700_000_000_000;
+    vi.setSystemTime(now);
+
+    const { result } = renderHook(() =>
+      useTypingBroadcast({ boardId: BOARD_ID, userId: USER_ID, context: CONTEXT }),
+    );
+
+    act(() => {
+      result.current.emit();
+    });
+
+    const call = stubChannel.send.mock.calls[0]?.[0] as {
+      payload: { user_id: string; context: string; at: number };
+    };
+    expect(call.payload.user_id).toBe(USER_ID);
+    expect(call.payload.context).toBe(CONTEXT);
+    expect(call.payload.at).toBe(now);
+  });
+
+  // -------------------------------------------------------------------------
+  // Visibility gate: hidden tabs should not emit
+  // -------------------------------------------------------------------------
+
+  it("emit() is suppressed when document.visibilityState is 'hidden'", () => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    });
+
+    const { result } = renderHook(() =>
+      useTypingBroadcast({ boardId: BOARD_ID, userId: USER_ID, context: CONTEXT }),
+    );
+
+    act(() => {
+      result.current.emit();
+    });
+
+    expect(stubChannel.send).not.toHaveBeenCalled();
+  });
+
+  it("emit() fires once tab becomes visible again after being hidden", () => {
+    // Start hidden
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    });
+
+    const { result } = renderHook(() =>
+      useTypingBroadcast({ boardId: BOARD_ID, userId: USER_ID, context: CONTEXT }),
+    );
+
+    act(() => {
+      result.current.emit(); // suppressed
+    });
+    expect(stubChannel.send).toHaveBeenCalledTimes(0);
+
+    // Advance past throttle window so next call is a fresh leading
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // Tab becomes visible
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+
+    act(() => {
+      result.current.emit(); // now visible — fires
+    });
+    expect(stubChannel.send).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Cancel on unmount: trailing call must not fire after unmount
+  // -------------------------------------------------------------------------
+
+  it("unmount cancels the pending throttle trailing call", () => {
+    const { result, unmount } = renderHook(() =>
+      useTypingBroadcast({ boardId: BOARD_ID, userId: USER_ID, context: CONTEXT }),
+    );
+
+    act(() => {
+      result.current.emit(); // leading
+      result.current.emit(); // queued trailing
+    });
+    expect(stubChannel.send).toHaveBeenCalledTimes(1);
+
+    // Unmount before trailing fires
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // Trailing call was cancelled by unmount — still only 1 send
+    expect(stubChannel.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("unmount calls channel.unsubscribe() and supabase.removeChannel()", () => {
+    const { unmount } = renderHook(() =>
+      useTypingBroadcast({ boardId: BOARD_ID, userId: USER_ID, context: CONTEXT }),
+    );
+
+    unmount();
+
+    expect(stubChannel.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(mockRemoveChannel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/use-typing-indicator.test.ts
+++ b/tests/unit/use-typing-indicator.test.ts
@@ -1,0 +1,122 @@
+// @ts-expect-error vitest is wired in epic 15
+import { describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock useBoardStore to control typingByContext
+// ---------------------------------------------------------------------------
+
+// We need to control what selector returns — keep a mutable map so individual
+// tests can populate it before rendering.
+let mockTypingByContext: Map<
+  string,
+  Array<{ user_id: string; context: string; at: number }>
+> = new Map();
+
+vi.mock("../../stores/board-store", () => ({
+  useBoardStore: (selector: (state: { typingByContext: typeof mockTypingByContext }) => unknown) =>
+    selector({ typingByContext: mockTypingByContext }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import the hook AFTER mocks
+// ---------------------------------------------------------------------------
+// @ts-expect-error renderHook is wired in epic 15
+import { renderHook } from "@testing-library/react";
+import { useTypingIndicator } from "../../hooks/use-typing-indicator";
+
+const CONTEXT = "comment:task-42";
+const OTHER_CONTEXT = "comment:task-99";
+
+describe.skip("useTypingIndicator", () => {
+  // -------------------------------------------------------------------------
+  // Self-filter: current user is excluded from results
+  // -------------------------------------------------------------------------
+
+  it("filters out the current user from the result list", () => {
+    mockTypingByContext = new Map([
+      [
+        CONTEXT,
+        [
+          { user_id: "u1", context: CONTEXT, at: 1000 },
+          { user_id: "u2", context: CONTEXT, at: 2000 },
+        ],
+      ],
+    ]);
+
+    const { result } = renderHook(() => useTypingIndicator({ userId: "u1", context: CONTEXT }));
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toEqual({ user_id: "u2", at: 2000 });
+  });
+
+  it("returns all entries when none match the current userId (no self present)", () => {
+    mockTypingByContext = new Map([
+      [
+        CONTEXT,
+        [
+          { user_id: "u2", context: CONTEXT, at: 1000 },
+          { user_id: "u3", context: CONTEXT, at: 2000 },
+        ],
+      ],
+    ]);
+
+    const { result } = renderHook(() => useTypingIndicator({ userId: "u1", context: CONTEXT }));
+
+    expect(result.current).toHaveLength(2);
+  });
+
+  it("returns an empty array when there are no typists in the context", () => {
+    mockTypingByContext = new Map(); // no entries at all
+
+    const { result } = renderHook(() => useTypingIndicator({ userId: "u1", context: CONTEXT }));
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns only entries for the matching context, not other contexts", () => {
+    mockTypingByContext = new Map([
+      [CONTEXT, [{ user_id: "u2", context: CONTEXT, at: 1000 }]],
+      [OTHER_CONTEXT, [{ user_id: "u3", context: OTHER_CONTEXT, at: 2000 }]],
+    ]);
+
+    const { result } = renderHook(() => useTypingIndicator({ userId: "u1", context: CONTEXT }));
+
+    // Should only see u2, not u3 (which is in a different context)
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toEqual({ user_id: "u2", at: 1000 });
+  });
+
+  it("returns an empty array when the only entry in the context is the current user", () => {
+    mockTypingByContext = new Map([[CONTEXT, [{ user_id: "u1", context: CONTEXT, at: 1000 }]]]);
+
+    const { result } = renderHook(() => useTypingIndicator({ userId: "u1", context: CONTEXT }));
+
+    expect(result.current).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Spec fixture: store seeded to typingByContext: { 'comment:t1': [{u1,at1}, {u2,at2}] }
+  // with userId: 'u1' — hook returns only [{u2, at2}]
+  // -------------------------------------------------------------------------
+
+  it("spec fixture: returns only [{ u2, at2 }] when userId is u1 and both are typing in comment:t1", () => {
+    const at1 = 1_000_000;
+    const at2 = 2_000_000;
+
+    mockTypingByContext = new Map([
+      [
+        "comment:t1",
+        [
+          { user_id: "u1", context: "comment:t1", at: at1 },
+          { user_id: "u2", context: "comment:t1", at: at2 },
+        ],
+      ],
+    ]);
+
+    const { result } = renderHook(() =>
+      useTypingIndicator({ userId: "u1", context: "comment:t1" }),
+    );
+
+    expect(result.current).toEqual([{ user_id: "u2", context: "comment:t1", at: at2 }]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the realtime substrate for Donezo: per-board postgres_changes subscriptions, presence (avatar pile), cursor broadcast, typing-indicator plumbing, connection-status UX, and an offline write queue with reconnect flush.

- **Epic doc:** [docs/conversion-plan/08-realtime-presence.md](docs/conversion-plan/08-realtime-presence.md)
- **Dispatch plan:** [docs/conversion-plan/_dispatch/epic-08.md](docs/conversion-plan/_dispatch/epic-08.md)
- **Followup round 1:** [docs/conversion-plan/_dispatch/epic-08-followup-1.md](docs/conversion-plan/_dispatch/epic-08-followup-1.md)

## What landed

**Schema (S0).** Denormalized `board_id` onto `cell` and `comment` with defense-in-depth consistency triggers mirroring the existing `task_board_id_consistency` pattern. Backfill from `task.board_id`, then NOT NULL + FK + index. Enables `filter: 'board_id=eq.<id>'` on postgres_changes.

**Store (S1).** Extended Zustand `useBoardStore` with `connection`, `presence`, `cursors`, `typingByContext` (transient) and `outbox` (persisted to localStorage alongside existing `collapsedByBoard` / `columnPrefsByBoard`). Outbox enforces a 4MB cap with `outboxOverflow` flag. Exported `selectPresentUserIds` / `selectUsersViewingTask` selectors.

**Realtime hook (S2).** `useBoardRealtime(boardId, userId)` opens one `board:<id>` channel with postgres_changes for `task`/`cell`/`group`/`column` (all filtered per-board; comment deferred to Epic 09), presence track/sync, broadcast for cursor + typing. Connection state machine: SUBSCRIBED / TIMED_OUT / CHANNEL_ERROR. On `reconnecting → SUBSCRIBED`, calls `router.refresh()` to re-run the RSC tree (no `unstable_cache` — direct refresh per the locked-in plan decision). 2s sweeper prunes expired cursors and typing entries. Throttle helper in `lib/realtime/throttle.ts`.

**Topbar UI (S3+S4).** `PresencePile` shows deduped-per-user avatars with green live dots. `ConnectionStatus` renders nothing when connected; yellow pulsing pill when reconnecting; red pill + offline message when offline. `OutboxBanner` placeholder (S8 filled it in).

**Cursor broadcast (S6).** `useCursorBroadcast` emits throttled (100ms) cursor positions, paused on hidden tabs. `CursorOverlay` renders colored dots on the cell. Stable user→color hash skips the red band reserved for offline. `BoardContext` extended to expose `userId`.

**Typing plumbing (S7).** `useTypingBroadcast` (emit) and `useTypingIndicator` (read, filters self) as libraries ready for Epic 09's comment composer. No production caller yet.

**Outbox (S8).** `withOutbox(actionId, action)` wraps upsert-style server actions; on offline or network error, enqueues to the persisted outbox. `flushOutbox()` replays in submission order, drops failures with a toast, resets the overflow flag on completion. Banner reads `outbox.length` and shows "Syncing N pending changes…".

**Integration (S5).** Realtime hook + outbox flush trigger mounted at `BoardTable`. Listens for `window 'online'` events and store `connection` transitions to `'connected'`. Playwright e2e at `tests/e2e/08-realtime.spec.ts` covers live cell edit / task add / presence / connection / cursor. `CONTRIBUTING.md` documents the invariant: writes go through server actions; realtime is read-only on the client.

**Followup round 1.** Reviewer caught three real gaps:
- **A:** `useTypingBroadcast` was tearing down the shared board channel on unmount. Fixed to mirror `useCursorBroadcast` — emit-only, no lifecycle.
- **B:** `data-testid` attrs and `data-task-id` / `data-column-id` were missing on the components the Playwright e2e queries. Added.
- **C:** `withOutbox` was exported but never invoked. Wired into the four upsert-style mutation call sites (`CellEditor`, `TaskTitleCell`, `BoardTable` group rename, `BulkActionBar` bulk cell set) via `lib/realtime/wrapped-actions.ts`.

## Locked-in plan decisions

- Cursors: ship.
- Typing: ship plumbing only; first consumer lands in Epic 09.
- Presence granularity: board-level only this epic (schema forward-compat for `task` viewing in Epic 09).
- Offline queue: upsert-only, localStorage, last-write-wins, banner UX. Inserts/deletes error immediately when offline.
- Reconnect refetch: `router.refresh()` not `unstable_cache`.
- Comment table postgres_changes: deferred to Epic 09.
- Pause cursor/typing broadcast emit on hidden tab: yes.

## Followups for later epics

- Comment realtime subscription (Epic 09).
- Per-row "viewing this task" presence dot (Epic 09 with task drawer).
- Cross-codebase `revalidateTag('board:<id>')` audit on mutation actions.
- Design-system tokens `--color-success`/`--color-warning`/`--color-danger` (Epic 14 polish).
- Per-channel auth tokens (future security epic).
- Mobile: disable cursor broadcast on small viewports (Epic 14).
- Cell DELETE postgres_changes — currently logged-only; add `applyCellDelete` if observed in practice.

## Test plan

- [ ] Local `supabase db reset` applies the new migration cleanly
- [ ] `pnpm tsc --noEmit` and `pnpm lint` are green (verified during execution)
- [ ] Open two browsers on the same board; edit a cell in one → other reflects within 1.5s
- [ ] Add a task in one → other sees it appear
- [ ] Both browsers' presence piles show the other user
- [ ] Force-offline one context → reconnecting/offline pill appears; restore → pill disappears and state syncs
- [ ] Hover a cell in browser A → colored dot appears on the same cell in browser B
- [ ] Disconnect, edit a cell (queues), reconnect → outbox banner appears then drains, value lands
- [ ] Vitest + pgTAP test runners land in Epic 15; current tests use `describe.skip` per repo convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)